### PR TITLE
fix: add --skip-detection flag to avoid redundant prompts after CLI s…

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -50,7 +50,15 @@
       "Bash(python3:*)",
       "Bash(git -C /home/xgueret/Workspace/01-projets/tools/ckad-dojo diff --stat)",
       "Bash(git -C /home/xgueret/Workspace/01-projets/tools/ckad-dojo tag -l)",
-      "Bash(git -C /home/xgueret/Workspace/01-projets/tools/ckad-dojo add -A)"
+      "Bash(git -C /home/xgueret/Workspace/01-projets/tools/ckad-dojo add -A)",
+      "Bash(git checkout:*)",
+      "Bash(git pull:*)",
+      "Bash(echo 'No matching local branches' ls -d specs/*skip-exam* specs/*fix-cli-setup*)",
+      "Bash(sort:*)",
+      "Bash(git rev-parse:*)",
+      "Bash(kubectl cluster-info:*)",
+      "Bash(timeout 10 ./scripts/ckad-exam.sh:*)",
+      "Bash(timeout 5 ./scripts/ckad-exam.sh:*)"
     ],
     "deny": [],
     "ask": []

--- a/ckad_dojo.py
+++ b/ckad_dojo.py
@@ -381,10 +381,10 @@ def menu_start_exam() -> None:
         print_error("Setup failed")
         return
 
-    # Run exam
+    # Run exam (skip detection since we just ran setup)
     print()
     print_info("Launching exam interface...")
-    run_script("ckad-exam.sh", ["web", "-e", exam_id])
+    run_script("ckad-exam.sh", ["web", "-e", exam_id, "--skip-detection"])
 
 
 def menu_score_exam() -> None:
@@ -505,10 +505,10 @@ def cmd_exam_start(args) -> int:
         print_error("Setup failed")
         return returncode
 
-    # Start exam
+    # Start exam (skip detection since we just ran setup)
     print()
     print_info("Launching exam interface...")
-    returncode, _, _ = run_script("ckad-exam.sh", ["web", "-e", exam_id])
+    returncode, _, _ = run_script("ckad-exam.sh", ["web", "-e", exam_id, "--skip-detection"])
     return returncode
 
 

--- a/scripts/ckad-exam.sh
+++ b/scripts/ckad-exam.sh
@@ -57,6 +57,7 @@ show_help() {
     echo "  --no-timer       Start exam without timer"
     echo "  --no-terminal    Disable embedded terminal panel"
     echo "  --no-docs        Don't open K8s/Helm documentation tabs"
+    echo "  --skip-detection Skip existing exam resource detection"
     echo "  --port PORT      Web interface port (default: $WEB_PORT)"
     echo "  --terminal-port PORT  Terminal port (default: 7681)"
     echo ""
@@ -183,6 +184,12 @@ detect_existing_exam_resources() {
 # Offer cleanup if resources from another exam exist
 check_and_offer_cleanup() {
     local target_exam=$1
+
+    # Skip detection if flag is set (used when CLI already ran setup)
+    if [ "$SKIP_DETECTION" = "true" ]; then
+        print_success "Skipping exam resource detection (--skip-detection)"
+        return 0
+    fi
 
     echo ""
     print_section "Checking for existing exam resources..."
@@ -738,6 +745,7 @@ SKIP_CONFIRM=false
 NO_TIMER=false
 NO_TERMINAL=false
 NO_DOCS=false
+SKIP_DETECTION=false
 INTERACTIVE_EXAM=true
 
 while [[ $# -gt 0 ]]; do
@@ -769,6 +777,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         --no-docs)
             NO_DOCS=true
+            shift
+            ;;
+        --skip-detection)
+            SKIP_DETECTION=true
             shift
             ;;
         --port)

--- a/specs/fix-cli-setup-exam-flow/checklists/requirements.md
+++ b/specs/fix-cli-setup-exam-flow/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Fix CLI Setup-Exam Flow
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2025-12-09
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass validation
+- Ready for `/speckit.tasks` to generate implementation tasks

--- a/specs/fix-cli-setup-exam-flow/spec.md
+++ b/specs/fix-cli-setup-exam-flow/spec.md
@@ -1,0 +1,97 @@
+# Feature Specification: Fix CLI Setup-Exam Flow
+
+**Feature Branch**: `fix/cli-setup-exam-flow`
+**Created**: 2025-12-09
+**Status**: Draft
+**Input**: User description: "Corriger le flux CLI setup-exam: quand ckad-dojo lance setup puis exam, le script ckad-exam.sh ne doit pas redemander si on veut cleanup les ressources qu'on vient de créer. Ajouter un flag --skip-detection pour bypasser la détection d'examen existant quand le setup vient d'être fait."
+
+## Problem Statement
+
+When users run `uv run ckad-dojo exam start`, the following happens:
+
+1. CLI runs `ckad-setup.sh -e <exam>` to setup the environment
+2. CLI then runs `ckad-exam.sh web -e <exam>` to launch the interface
+3. `ckad-exam.sh` detects existing resources (that were just created in step 1)
+4. User is prompted to choose: cleanup, continue, or cancel
+
+This is **redundant and confusing** because:
+- The resources were JUST created intentionally
+- The user already made the decision to start the exam
+- Asking again breaks the user flow
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Seamless Exam Start via CLI (Priority: P1)
+
+As a user starting an exam via the unified CLI (`uv run ckad-dojo exam start`), I want the setup and exam launch to flow seamlessly without redundant prompts.
+
+**Why this priority**: This is the primary use case that caused the bug. The CLI is the recommended way to use the tool.
+
+**Independent Test**: Run `uv run ckad-dojo exam start -e ckad-simulation1` and verify the exam interface opens directly after setup without any additional prompts.
+
+**Acceptance Scenarios**:
+
+1. **Given** I run `uv run ckad-dojo exam start -e ckad-simulation1`, **When** the setup completes successfully, **Then** the exam interface opens immediately without asking about existing resources.
+2. **Given** I run `uv run ckad-dojo` and select "Start Exam", **When** setup completes, **Then** the exam interface opens without redundant prompts.
+
+---
+
+### User Story 2 - Direct Script Usage Unchanged (Priority: P2)
+
+As a user running `ckad-exam.sh` directly (not via CLI), I still want to see the existing exam detection warning if resources exist.
+
+**Why this priority**: Preserves backward compatibility for users who don't use the unified CLI.
+
+**Independent Test**: Run `./scripts/ckad-exam.sh web -e ckad-simulation1` when resources already exist and verify the detection prompt appears.
+
+**Acceptance Scenarios**:
+
+1. **Given** exam resources already exist, **When** I run `./scripts/ckad-exam.sh web -e ckad-simulation1` directly, **Then** I see the existing exam detection prompt.
+2. **Given** no exam resources exist, **When** I run `./scripts/ckad-exam.sh web -e ckad-simulation1` directly, **Then** setup runs and exam starts normally.
+
+---
+
+### Edge Cases
+
+- What happens if setup fails? → Exam should NOT launch (current behavior preserved)
+- What happens if user cancels during setup? → Process should exit cleanly
+- What happens if --skip-detection is used but resources don't match the exam ID? → Should still skip detection (trust the flag)
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: `ckad-exam.sh` MUST accept a `--skip-detection` flag to bypass existing exam resource detection
+- **FR-002**: When `--skip-detection` is passed, the script MUST skip the "EXISTING EXAM DETECTED" check entirely
+- **FR-003**: The Python CLI (`ckad_dojo.py`) MUST pass `--skip-detection` when calling `ckad-exam.sh` after a successful setup
+- **FR-004**: Direct usage of `ckad-exam.sh` without the flag MUST preserve current behavior (show detection prompt)
+- **FR-005**: The `--skip-detection` flag MUST be documented in the script's help output
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Users can start an exam via CLI without any redundant prompts (0 extra confirmation dialogs)
+- **SC-002**: Direct script usage continues to show detection prompt when appropriate (100% backward compatible)
+- **SC-003**: The end-to-end flow `uv run ckad-dojo exam start` completes in one continuous flow
+
+## Technical Notes
+
+### Files to Modify
+
+1. `scripts/ckad-exam.sh` - Add `--skip-detection` flag handling
+2. `ckad_dojo.py` - Pass `--skip-detection` when calling `ckad-exam.sh` after setup
+
+### Implementation Approach
+
+The `--skip-detection` flag should:
+- Be parsed in the argument handling section of `ckad-exam.sh`
+- Set a variable like `SKIP_DETECTION=true`
+- Check this variable before the "EXISTING EXAM DETECTED" block
+- If `SKIP_DETECTION=true`, skip the entire detection logic
+
+## Assumptions
+
+- The setup script (`ckad-setup.sh`) always creates the resources correctly
+- If setup succeeds, we can trust that resources are valid for the exam
+- Users using direct scripts are advanced users who want full control

--- a/specs/fix-cli-setup-exam-flow/tasks.md
+++ b/specs/fix-cli-setup-exam-flow/tasks.md
@@ -1,0 +1,114 @@
+# Tasks: Fix CLI Setup-Exam Flow
+
+**Input**: Design documents from `/specs/fix-cli-setup-exam-flow/`
+**Prerequisites**: spec.md
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2)
+- Include exact file paths in descriptions
+
+---
+
+## Phase 1: Setup (Bash Script Modification)
+
+**Purpose**: Add --skip-detection flag support to ckad-exam.sh
+
+- [x] T001 Add SKIP_DETECTION variable initialization in scripts/ckad-exam.sh
+- [x] T002 Add --skip-detection flag parsing in argument handling section of scripts/ckad-exam.sh
+- [x] T003 Update show_help() to document --skip-detection flag in scripts/ckad-exam.sh
+
+---
+
+## Phase 2: User Story 1 - Seamless Exam Start via CLI (Priority: P1) 🎯 MVP
+
+**Goal**: CLI users can start exams without redundant detection prompts
+
+**Independent Test**: Run `uv run ckad-dojo exam start -e ckad-simulation1` and verify no detection prompt appears
+
+### Implementation for User Story 1
+
+- [x] T004 [US1] Add detection skip logic before "EXISTING EXAM DETECTED" block in scripts/ckad-exam.sh
+- [x] T005 [US1] Update cmd_exam_start() to pass --skip-detection flag in ckad_dojo.py
+- [x] T006 [US1] Update menu_start_exam() to pass --skip-detection flag in ckad_dojo.py
+
+**Checkpoint**: CLI exam start flow should work without redundant prompts
+
+---
+
+## Phase 3: User Story 2 - Direct Script Usage Unchanged (Priority: P2)
+
+**Goal**: Direct script users still see detection prompt (backward compatibility)
+
+**Independent Test**: Run `./scripts/ckad-exam.sh web -e ckad-simulation1` with existing resources and verify detection prompt appears
+
+### Implementation for User Story 2
+
+- [x] T007 [US2] Verify default behavior (SKIP_DETECTION=false) preserves detection in scripts/ckad-exam.sh
+- [x] T008 [US2] Test direct script usage shows detection prompt
+
+**Checkpoint**: Both CLI and direct script usage work as expected
+
+---
+
+## Phase 4: Polish & Validation
+
+**Purpose**: Final verification and cleanup
+
+- [x] T009 Run full integration test: `uv run ckad-dojo exam start -e ckad-simulation1`
+- [x] T010 Run direct script test: `./scripts/ckad-exam.sh web -e ckad-simulation1`
+- [x] T011 Verify --help shows --skip-detection documentation
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies - add flag support first
+- **US1 (Phase 2)**: Depends on Phase 1 - uses the new flag
+- **US2 (Phase 3)**: No code changes, just verification
+- **Polish (Phase 4)**: Depends on US1 and US2
+
+### Task Dependencies
+
+- T001 → T002 → T003 (sequential setup)
+- T004 depends on T002 (flag must be parsed first)
+- T005, T006 depend on T004 (detection skip must work first)
+- T007, T008 can run after T004
+
+### Parallel Opportunities
+
+- T005 and T006 can run in parallel (different functions in same file)
+- T009, T010, T011 can run in parallel (independent tests)
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Add flag support to bash script
+2. Complete Phase 2: Update Python CLI to use the flag
+3. **STOP and VALIDATE**: Test `uv run ckad-dojo exam start`
+4. If working, proceed to Phase 3 (verification)
+
+### Files Modified
+
+| File | Changes |
+|------|---------|
+| `scripts/ckad-exam.sh` | Add --skip-detection flag, update help, add skip logic |
+| `ckad_dojo.py` | Pass --skip-detection in cmd_exam_start() and menu_start_exam() |
+
+---
+
+## Summary
+
+- **Total Tasks**: 11
+- **US1 (CLI Flow)**: 3 tasks (T004-T006)
+- **US2 (Backward Compat)**: 2 tasks (T007-T008)
+- **Setup/Polish**: 6 tasks
+- **Parallel Opportunities**: T005/T006, T009/T010/T011


### PR DESCRIPTION
…etup

When using `uv run ckad-dojo exam start`, the setup runs first then the exam launcher. Previously, the launcher would detect the resources just created and ask the user what to do - redundant and confusing.

Changes:
- Add --skip-detection flag to ckad-exam.sh
- CLI passes --skip-detection after successful setup
- Direct script usage unchanged (backward compatible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)