### PR TITLE
fix(tests): remove simulation1 references from tests and scripts

### DIFF
--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -17,7 +17,7 @@ PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 EXAMS_DIR="$PROJECT_DIR/exams"
 
 # Default exam configuration
-DEFAULT_EXAM_ID="ckad-simulation1"
+DEFAULT_EXAM_ID="ckad-simulation2"
 CURRENT_EXAM_ID="${CURRENT_EXAM_ID:-$DEFAULT_EXAM_ID}"
 
 # Legacy paths (for backward compatibility)

--- a/tests/test-banner.sh
+++ b/tests/test-banner.sh
@@ -64,13 +64,14 @@ assert_contains "$_banner_output" "min" "Output should mention duration"
 # ----------------------------------------------------------------------------
 test_case "show_dojo_banner loads exam configuration"
 
-# Test with simulation1
-_banner_sim1=$(show_dojo_banner "ckad-simulation1" 2>&1)
-assert_contains "$_banner_sim1" "Seiryu" "Simulation1 should show Seiryu dojo name"
-
+# Note: ckad-simulation1 is LOCAL ONLY (not in git repo)
 # Test with simulation2
 _banner_sim2=$(show_dojo_banner "ckad-simulation2" 2>&1)
 assert_contains "$_banner_sim2" "Suzaku" "Simulation2 should show Suzaku dojo name"
+
+# Test with simulation3
+_banner_sim3=$(show_dojo_banner "ckad-simulation3" 2>&1)
+assert_contains "$_banner_sim3" "Byakko" "Simulation3 should show Byakko dojo name"
 
 # ----------------------------------------------------------------------------
 # Test: show_dojo_banner with invalid exam_id uses defaults

--- a/tests/test-common.sh
+++ b/tests/test-common.sh
@@ -117,8 +117,9 @@ rm -f "$TEMP_FILE"
 # ----------------------------------------------------------------------------
 test_case "exam_exists function works correctly"
 
-assert_true 'exam_exists "ckad-simulation1"' "ckad-simulation1 should exist"
+# Note: ckad-simulation1 is LOCAL ONLY (not in git repo)
 assert_true 'exam_exists "ckad-simulation2"' "ckad-simulation2 should exist"
+assert_true 'exam_exists "ckad-simulation3"' "ckad-simulation3 should exist"
 assert_true '! exam_exists "nonexistent-exam"' "nonexistent-exam should not exist"
 
 # ----------------------------------------------------------------------------
@@ -127,31 +128,33 @@ assert_true '! exam_exists "nonexistent-exam"' "nonexistent-exam should not exis
 test_case "list_available_exams function works correctly"
 
 exams=$(list_available_exams)
-assert_contains "$exams" "ckad-simulation1" "Should list ckad-simulation1"
+# Note: ckad-simulation1 is LOCAL ONLY (not in git repo)
 assert_contains "$exams" "ckad-simulation2" "Should list ckad-simulation2"
+assert_contains "$exams" "ckad-simulation3" "Should list ckad-simulation3"
 
 # ----------------------------------------------------------------------------
 # Test: load_exam function
 # ----------------------------------------------------------------------------
 test_case "load_exam function works correctly"
 
-# Load simulation1
-if load_exam "ckad-simulation1"; then
-	assert_equals "ckad-simulation1" "$CURRENT_EXAM_ID" "CURRENT_EXAM_ID should be set"
+# Note: ckad-simulation1 is LOCAL ONLY (not in git repo)
+# Load simulation2
+if load_exam "ckad-simulation2"; then
+	assert_equals "ckad-simulation2" "$CURRENT_EXAM_ID" "CURRENT_EXAM_ID should be set"
 	assert_not_empty "$EXAM_NAME" "EXAM_NAME should be set"
 	assert_not_empty "$TOTAL_QUESTIONS" "TOTAL_QUESTIONS should be set"
 	assert_not_empty "$TOTAL_POINTS" "TOTAL_POINTS should be set"
 	assert_true '[ ${#EXAM_NAMESPACES[@]} -gt 0 ]' "EXAM_NAMESPACES should have elements"
-else
-	assert_true 'false' "load_exam should succeed for ckad-simulation1"
-fi
-
-# Load simulation2
-if load_exam "ckad-simulation2"; then
-	assert_equals "ckad-simulation2" "$CURRENT_EXAM_ID" "CURRENT_EXAM_ID should be set for simulation2"
 	assert_contains "${EXAM_NAMESPACES[*]}" "blaze" "simulation2 should have blaze namespace"
 else
 	assert_true 'false' "load_exam should succeed for ckad-simulation2"
+fi
+
+# Load simulation3
+if load_exam "ckad-simulation3"; then
+	assert_equals "ckad-simulation3" "$CURRENT_EXAM_ID" "CURRENT_EXAM_ID should be set for simulation3"
+else
+	assert_true 'false' "load_exam should succeed for ckad-simulation3"
 fi
 
 # Try to load nonexistent exam
@@ -227,7 +230,7 @@ assert_function_exists "open_docs_tabs" "open_docs_tabs function should exist"
 test_case "Default exam configuration is set"
 
 assert_not_empty "$DEFAULT_EXAM_ID" "DEFAULT_EXAM_ID should be set"
-assert_equals "ckad-simulation1" "$DEFAULT_EXAM_ID" "DEFAULT_EXAM_ID should be ckad-simulation1"
+assert_equals "ckad-simulation2" "$DEFAULT_EXAM_ID" "DEFAULT_EXAM_ID should be ckad-simulation2"
 
 # ----------------------------------------------------------------------------
 # Test: Legacy path variables
@@ -242,13 +245,8 @@ assert_contains "$EXAM_DIR" "exam/course" "EXAM_DIR should contain exam/course"
 # ----------------------------------------------------------------------------
 test_case "load_exam sets all required paths"
 
-# Use a complete exam for this test (simulation1 may be gitignored)
-_test_exam="ckad-simulation1"
-if ! exam_is_complete "$_test_exam" "$PROJECT_DIR"; then
-	_test_exam="ckad-simulation2"
-fi
-
-load_exam "$_test_exam" >/dev/null 2>&1
+# Note: ckad-simulation1 is LOCAL ONLY (not in git repo)
+load_exam "ckad-simulation2" >/dev/null 2>&1
 assert_not_empty "$CURRENT_EXAM_DIR" "CURRENT_EXAM_DIR should be set"
 assert_not_empty "$CURRENT_MANIFESTS_DIR" "CURRENT_MANIFESTS_DIR should be set"
 assert_not_empty "$CURRENT_TEMPLATES_DIR" "CURRENT_TEMPLATES_DIR should be set"

--- a/tests/test-setup-functions.sh
+++ b/tests/test-setup-functions.sh
@@ -45,80 +45,68 @@ assert_function_exists "wait_for_namespace_deletion" "wait_for_namespace_deletio
 # ----------------------------------------------------------------------------
 test_case "Setup functions use dynamic exam configuration"
 
-# Load simulation1 if complete, otherwise use simulation2 for first test
-if exam_is_complete "ckad-simulation1" "$PROJECT_DIR"; then
-	load_exam "ckad-simulation1"
-
-	assert_not_empty "$CURRENT_MANIFESTS_DIR" "CURRENT_MANIFESTS_DIR should be set after load_exam"
-	assert_not_empty "$CURRENT_TEMPLATES_DIR" "CURRENT_TEMPLATES_DIR should be set after load_exam"
-	assert_contains "$CURRENT_MANIFESTS_DIR" "ckad-simulation1" "Manifests dir should contain exam id"
-	assert_contains "$CURRENT_TEMPLATES_DIR" "ckad-simulation1" "Templates dir should contain exam id"
-
-	# Verify namespaces are from config
-	assert_true '[ ${#EXAM_NAMESPACES[@]} -gt 0 ]' "EXAM_NAMESPACES should have elements"
-	assert_contains "${EXAM_NAMESPACES[*]}" "neptune" "simulation1 should have neptune namespace"
-else
-	skip_test "simulation1 files are gitignored - testing with simulation2 only"
-fi
-
-# Load simulation2 and verify different namespaces
+# Note: ckad-simulation1 is LOCAL ONLY (not in git repo)
+# Test with simulation2
 load_exam "ckad-simulation2"
 
 assert_not_empty "$CURRENT_MANIFESTS_DIR" "CURRENT_MANIFESTS_DIR should be set after load_exam"
+assert_not_empty "$CURRENT_TEMPLATES_DIR" "CURRENT_TEMPLATES_DIR should be set after load_exam"
 assert_contains "$CURRENT_MANIFESTS_DIR" "ckad-simulation2" "Manifests dir should contain exam id"
+assert_contains "$CURRENT_TEMPLATES_DIR" "ckad-simulation2" "Templates dir should contain exam id"
+
+# Verify namespaces are from config
+assert_true '[ ${#EXAM_NAMESPACES[@]} -gt 0 ]' "EXAM_NAMESPACES should have elements"
 assert_contains "${EXAM_NAMESPACES[*]}" "blaze" "simulation2 should have blaze namespace"
+
+# Test with simulation3
+load_exam "ckad-simulation3"
+
+assert_not_empty "$CURRENT_MANIFESTS_DIR" "CURRENT_MANIFESTS_DIR should be set after load_exam"
+assert_contains "$CURRENT_MANIFESTS_DIR" "ckad-simulation3" "Manifests dir should contain exam id"
 
 # ----------------------------------------------------------------------------
 # Test: Exam directory structure
 # ----------------------------------------------------------------------------
 test_case "Exam directory structures exist"
 
-# Check simulation1 structure (may be gitignored)
-assert_dir_exists "$PROJECT_DIR/exams/ckad-simulation1" "simulation1 exam dir should exist"
-assert_file_exists "$PROJECT_DIR/exams/ckad-simulation1/exam.conf" "simulation1 exam.conf should exist"
-if exam_is_complete "ckad-simulation1" "$PROJECT_DIR"; then
-	assert_file_exists "$PROJECT_DIR/exams/ckad-simulation1/questions.md" "simulation1 questions.md should exist"
-	assert_file_exists "$PROJECT_DIR/exams/ckad-simulation1/scoring-functions.sh" "simulation1 scoring-functions.sh should exist"
-	assert_dir_exists "$PROJECT_DIR/exams/ckad-simulation1/manifests/setup" "simulation1 manifests/setup should exist"
-	assert_dir_exists "$PROJECT_DIR/exams/ckad-simulation1/templates" "simulation1 templates should exist"
-else
-	skip_test "simulation1 files are gitignored"
-fi
-
+# Note: ckad-simulation1 is LOCAL ONLY (not in git repo)
 # Check simulation2 structure
 assert_dir_exists "$PROJECT_DIR/exams/ckad-simulation2" "simulation2 exam dir should exist"
 assert_file_exists "$PROJECT_DIR/exams/ckad-simulation2/exam.conf" "simulation2 exam.conf should exist"
 assert_file_exists "$PROJECT_DIR/exams/ckad-simulation2/questions.md" "simulation2 questions.md should exist"
 assert_file_exists "$PROJECT_DIR/exams/ckad-simulation2/scoring-functions.sh" "simulation2 scoring-functions.sh should exist"
+assert_dir_exists "$PROJECT_DIR/exams/ckad-simulation2/manifests/setup" "simulation2 manifests/setup should exist"
+assert_dir_exists "$PROJECT_DIR/exams/ckad-simulation2/templates" "simulation2 templates should exist"
+
+# Check simulation3 structure
+assert_dir_exists "$PROJECT_DIR/exams/ckad-simulation3" "simulation3 exam dir should exist"
+assert_file_exists "$PROJECT_DIR/exams/ckad-simulation3/exam.conf" "simulation3 exam.conf should exist"
+assert_file_exists "$PROJECT_DIR/exams/ckad-simulation3/questions.md" "simulation3 questions.md should exist"
+assert_file_exists "$PROJECT_DIR/exams/ckad-simulation3/scoring-functions.sh" "simulation3 scoring-functions.sh should exist"
 
 # ----------------------------------------------------------------------------
 # Test: Manifest files exist
 # ----------------------------------------------------------------------------
-test_case "Manifest files exist for both exams"
+test_case "Manifest files exist for public exams"
 
-if exam_is_complete "ckad-simulation1" "$PROJECT_DIR"; then
-	assert_file_exists "$PROJECT_DIR/exams/ckad-simulation1/manifests/setup/namespaces.yaml" "simulation1 namespaces.yaml should exist"
-else
-	skip_test "simulation1 manifests are gitignored"
-fi
+# Note: ckad-simulation1 is LOCAL ONLY (not in git repo)
 assert_file_exists "$PROJECT_DIR/exams/ckad-simulation2/manifests/setup/namespaces.yaml" "simulation2 namespaces.yaml should exist"
+assert_file_exists "$PROJECT_DIR/exams/ckad-simulation3/manifests/setup/namespaces.yaml" "simulation3 namespaces.yaml should exist"
 
 # ----------------------------------------------------------------------------
 # Test: HELM configuration
 # ----------------------------------------------------------------------------
 test_case "Helm configuration is set in exam configs"
 
-if exam_is_complete "ckad-simulation1" "$PROJECT_DIR"; then
-	load_exam "ckad-simulation1"
-	assert_not_empty "$HELM_NAMESPACE" "HELM_NAMESPACE should be set for simulation1"
-	assert_true '[ ${#HELM_RELEASES[@]} -gt 0 ]' "HELM_RELEASES should have elements for simulation1"
-else
-	skip_test "simulation1 files are gitignored"
-fi
-
+# Note: ckad-simulation1 is LOCAL ONLY (not in git repo)
+# Only simulation2 has HELM_RELEASES defined
 load_exam "ckad-simulation2"
 assert_not_empty "$HELM_NAMESPACE" "HELM_NAMESPACE should be set for simulation2"
 assert_true '[ ${#HELM_RELEASES[@]} -gt 0 ]' "HELM_RELEASES should have elements for simulation2"
+
+# Other simulations have HELM_NAMESPACE but empty HELM_RELEASES (this is valid)
+load_exam "ckad-simulation3"
+assert_not_empty "$HELM_NAMESPACE" "HELM_NAMESPACE should be set for simulation3"
 
 # ============================================================================
 # SUMMARY


### PR DESCRIPTION
- Update DEFAULT_EXAM_ID from simulation1 to simulation2 in common.sh
- Update test-common.sh to test simulation2/3 instead of simulation1
- Update test-banner.sh to test Suzaku/Byakko instead of Seiryu
- Update test-setup-functions.sh to only test public simulations

Simulation 1 (Dojo Seiryu) is LOCAL ONLY and not available in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Description

Brief description of the changes in this PR.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #(issue number)

## Checklist

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
- [ ] My code follows the project's style guidelines
- [ ] I have run `pre-commit run --all-files` and fixed any issues
- [ ] I have run `./tests/run-tests.sh` and all tests pass
- [ ] I have updated the documentation if needed
- [ ] I have added tests for new functionality (if applicable)

## Testing Done

Describe how you tested your changes:

- [ ] Manual testing
- [ ] Unit tests added/updated
- [ ] Tested on local Kubernetes cluster

## Screenshots (if applicable)

Add screenshots to show visual changes.
