### PR TITLE
feat(cli): add --no-hints option to disable hint boxes

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ cd ckad-dojo
 
 | Tool | Version | Purpose | Installation |
 |------|---------|---------|--------------|
-| Kubernetes cluster | 1.28+ | kubeadm, minikube, kind... | [kubernetes.io](https://kubernetes.io/docs/setup/) |
+| Kubernetes cluster | 1.28+ | kubeadm, minikube, kind... | [kubernetes.io](https://kubernetes.io/docs/setup/) or [vagrant-k8s-cluster](https://github.com/TiPunchLabs/vagrant-k8s-cluster) |
 | `kubectl` | 1.28+ | Kubernetes CLI | `curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"` |
 | `helm` | 3.x | Package manager | `curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 \| bash` |
 | `docker` | 20.x+ | Container runtime | [docs.docker.com](https://docs.docker.com/engine/install/) |
@@ -358,6 +358,7 @@ uv run ckad-dojo completion fish > ~/.config/fish/completions/ckad-dojo.fish
 | `--no-terminal` | Disable embedded terminal panel |
 | `--no-docs` | Don't open K8s/Helm documentation tabs |
 | `--no-pause` | Disable timer pause functionality |
+| `--no-hints` | Disable hints (remove Hint/Tip boxes) |
 | `--browser NAME` | Browser to use (firefox, chrome, chromium, brave, default) |
 | `--port PORT` | Use custom port (default: 9090) |
 | `--terminal-port PORT` | Terminal port (default: 7681) |

--- a/ckad_dojo.py
+++ b/ckad_dojo.py
@@ -521,6 +521,8 @@ def cmd_exam_start(args) -> int:
     script_args = ["web", "-e", exam_id, "--skip-detection", "--browser", browser]
     if getattr(args, 'no_pause', False):
         script_args.append("--no-pause")
+    if getattr(args, 'no_hints', False):
+        script_args.append("--no-hints")
     returncode, _, _ = run_script("ckad-exam.sh", script_args)
     return returncode
 
@@ -1033,6 +1035,11 @@ def create_parser() -> argparse.ArgumentParser:
         "--no-pause",
         action="store_true",
         help="Disable timer pause functionality"
+    )
+    exam_start.add_argument(
+        "--no-hints",
+        action="store_true",
+        help="Disable hints (remove Hint/Tip boxes)"
     )
 
     exam_subparsers.add_parser("stop", help="Stop current exam session")


### PR DESCRIPTION
- Add --no-hints argument to Python CLI (ckad_dojo.py)
- Document --no-hints option in README Launch Options table
- Add vagrant-k8s-cluster link as alternative K8s cluster setup option

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Description

Brief description of the changes in this PR.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #(issue number)

## Checklist

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
- [ ] My code follows the project's style guidelines
- [ ] I have run `pre-commit run --all-files` and fixed any issues
- [ ] I have run `./tests/run-tests.sh` and all tests pass
- [ ] I have updated the documentation if needed
- [ ] I have added tests for new functionality (if applicable)

## Testing Done

Describe how you tested your changes:

- [ ] Manual testing
- [ ] Unit tests added/updated
- [ ] Tested on local Kubernetes cluster

## Screenshots (if applicable)

Add screenshots to show visual changes.
