### PR TITLE
fix(simulation7): correct scoring functions for Q4 and Q9

### DIFF
--- a/exams/ckad-simulation7/scoring-functions.sh
+++ b/exams/ckad-simulation7/scoring-functions.sh
@@ -136,10 +136,11 @@ score_q4() {
 		((score += 2))
 		details+="Pod debug-pod exists. "
 
-		# Check command
-		local args
+		# Check command (may be in args or command field)
+		local args cmd
 		args=$(kubectl get pod debug-pod -n meadow -o jsonpath='{.spec.containers[0].args}' 2>/dev/null)
-		if [[ "$args" == *"notexist"* ]]; then
+		cmd=$(kubectl get pod debug-pod -n meadow -o jsonpath='{.spec.containers[0].command}' 2>/dev/null)
+		if [[ "$args" == *"notexist"* ]] || [[ "$cmd" == *"notexist"* ]]; then
 			((score += 1))
 			details+="Error command configured. "
 		else
@@ -352,9 +353,9 @@ score_q9() {
 			details+="Max replicas incorrect ($max_replicas). "
 		fi
 
-		# Check CPU target
+		# Check CPU target (autoscaling/v2 uses metrics array)
 		local cpu_target
-		cpu_target=$(kubectl get hpa app-deploy -n root -o jsonpath='{.spec.targetCPUUtilizationPercentage}' 2>/dev/null)
+		cpu_target=$(kubectl get hpa app-deploy -n root -o jsonpath='{.spec.metrics[0].resource.target.averageUtilization}' 2>/dev/null)
 		if [[ "$cpu_target" == "80" ]]; then
 			((score += 2))
 			details+="CPU target 80% correct."


### PR DESCRIPTION
- Q4: Check both 'command' and 'args' fields for error command detection The pod may use either field depending on how it was created
- Q9: Use autoscaling/v2 API path for CPU target verification The old 'targetCPUUtilizationPercentage' field doesn't exist in v2 API, replaced with 'metrics[0].resource.target.averageUtilization'

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Description

Brief description of the changes in this PR.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #(issue number)

## Checklist

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
- [ ] My code follows the project's style guidelines
- [ ] I have run `pre-commit run --all-files` and fixed any issues
- [ ] I have run `./tests/run-tests.sh` and all tests pass
- [ ] I have updated the documentation if needed
- [ ] I have added tests for new functionality (if applicable)

## Testing Done

Describe how you tested your changes:

- [ ] Manual testing
- [ ] Unit tests added/updated
- [ ] Tested on local Kubernetes cluster

## Screenshots (if applicable)

Add screenshots to show visual changes.
