### PR TITLE
fix(cleanup): auto-detect active exam for cleanup

### DIFF
--- a/scripts/ckad-cleanup.sh
+++ b/scripts/ckad-cleanup.sh
@@ -54,7 +54,8 @@ list_exams() {
 SKIP_CONFIRM=false
 KEEP_REGISTRY=false
 KEEP_DIRS=false
-SELECTED_EXAM="$DEFAULT_EXAM_ID"
+EXAM_SPECIFIED=false
+SELECTED_EXAM=""
 
 while [[ $# -gt 0 ]]; do
 	case $1 in
@@ -64,6 +65,7 @@ while [[ $# -gt 0 ]]; do
 		;;
 	-e | --exam)
 		SELECTED_EXAM="$2"
+		EXAM_SPECIFIED=true
 		shift 2
 		;;
 	-y | --yes)
@@ -93,6 +95,19 @@ done
 # Main cleanup function
 main() {
 	local start_time=$(date +%s)
+
+	# Auto-detect active exam if not specified
+	if [ "$EXAM_SPECIFIED" = false ]; then
+		local active_exam
+		active_exam=$(get_active_exam)
+		if [ -n "$active_exam" ]; then
+			SELECTED_EXAM="$active_exam"
+			echo -e "${CYAN}Auto-detected active exam: $SELECTED_EXAM${NC}"
+		else
+			SELECTED_EXAM="$DEFAULT_EXAM_ID"
+			echo -e "${YELLOW}No active exam detected, using default: $SELECTED_EXAM${NC}"
+		fi
+	fi
 
 	# Load exam configuration
 	if ! load_exam "$SELECTED_EXAM"; then
@@ -185,6 +200,9 @@ main() {
 
 	# Wait for namespace deletion
 	wait_for_namespace_deletion
+
+	# Clear active exam state
+	clear_active_exam
 
 	# Summary
 	local end_time=$(date +%s)

--- a/scripts/ckad-exam.sh
+++ b/scripts/ckad-exam.sh
@@ -528,6 +528,9 @@ start_web() {
 	# Stop any existing timer
 	timer_stop 2>/dev/null || true
 
+	# Save active exam state (for cleanup auto-detection)
+	save_active_exam "$exam_id"
+
 	# Check if port is available
 	if lsof -Pi :$WEB_PORT -sTCP:LISTEN -t >/dev/null 2>&1; then
 		echo ""
@@ -633,6 +636,9 @@ start_exam() {
 
 	# Stop any existing timer
 	timer_stop 2>/dev/null
+
+	# Save active exam state (for cleanup auto-detection)
+	save_active_exam "$exam_id"
 
 	# Start timer (unless disabled)
 	if [ "$no_timer" != "true" ]; then

--- a/scripts/ckad-setup.sh
+++ b/scripts/ckad-setup.sh
@@ -123,6 +123,9 @@ main() {
 		((errors++))
 	fi
 
+	# Save the active exam state (for cleanup auto-detection)
+	save_active_exam "$CURRENT_EXAM_ID"
+
 	# Step 2: Deploy pre-existing resources
 	setup_resources
 	local resource_errors=$?

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -84,6 +84,43 @@ exam_exists() {
 	[ -d "$EXAMS_DIR/$exam_id" ] && [ -f "$EXAMS_DIR/$exam_id/exam.conf" ]
 }
 
+# ============================================================================
+# ACTIVE EXAM STATE MANAGEMENT
+# ============================================================================
+
+# State file for tracking the currently active exam
+EXAM_STATE_DIR="${EXAM_STATE_DIR:-/tmp/ckad-dojo}"
+EXAM_STATE_FILE="$EXAM_STATE_DIR/active-exam.state"
+
+# Save the active exam ID to state file
+# Usage: save_active_exam <exam_id>
+save_active_exam() {
+	local exam_id=$1
+	mkdir -p "$EXAM_STATE_DIR"
+	echo "ACTIVE_EXAM_ID=$exam_id" >"$EXAM_STATE_FILE"
+	echo "ACTIVE_SINCE=$(date +%s)" >>"$EXAM_STATE_FILE"
+}
+
+# Get the active exam ID from state file
+# Returns: exam_id if found, empty string otherwise
+get_active_exam() {
+	if [ -f "$EXAM_STATE_FILE" ]; then
+		local exam_id
+		exam_id=$(grep "^ACTIVE_EXAM_ID=" "$EXAM_STATE_FILE" 2>/dev/null | cut -d= -f2)
+		if [ -n "$exam_id" ] && exam_exists "$exam_id"; then
+			echo "$exam_id"
+			return 0
+		fi
+	fi
+	echo ""
+	return 1
+}
+
+# Clear the active exam state
+clear_active_exam() {
+	rm -f "$EXAM_STATE_FILE"
+}
+
 # Print functions
 print_header() {
 	echo -e "${BLUE}╔════════════════════════════════════════════════════════════════╗${NC}"


### PR DESCRIPTION
When running ckad-cleanup.sh without specifying an exam with -e, the script now auto-detects which exam is currently active instead of using the default exam.

Changes:
- Add save_active_exam(), get_active_exam(), clear_active_exam() functions to common.sh for state management
- Save active exam ID in /tmp/ckad-dojo/active-exam.state during setup, exam start (CLI and web mode)
- Update cleanup to auto-detect active exam if not specified
- Clear active exam state after successful cleanup

This fixes an issue where running cleanup without -e would clean the wrong simulation's namespaces if a different simulation was active.

## Description

Brief description of the changes in this PR.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #(issue number)

## Checklist

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
- [ ] My code follows the project's style guidelines
- [ ] I have run `pre-commit run --all-files` and fixed any issues
- [ ] I have run `./tests/run-tests.sh` and all tests pass
- [ ] I have updated the documentation if needed
- [ ] I have added tests for new functionality (if applicable)

## Testing Done

Describe how you tested your changes:

- [ ] Manual testing
- [ ] Unit tests added/updated
- [ ] Tested on local Kubernetes cluster

## Screenshots (if applicable)

Add screenshots to show visual changes.
