### PR TITLE
Ci/add security build jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,9 +49,9 @@ jobs:
         run: uvx pip-audit
 
       - name: Secret scan
-        uses: gitleaks/gitleaks-action@v2
-        env:
-          GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
+        run: |
+          wget -qO- https://github.com/gitleaks/gitleaks/releases/download/v8.24.3/gitleaks_8.24.3_linux_x64.tar.gz | tar xz
+          ./gitleaks detect --source . --verbose
 
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,3 +33,40 @@ jobs:
 
       - name: Run tests
         run: ./tests/run-tests.sh
+
+  security:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Audit dependencies
+        run: uvx pip-audit
+
+      - name: Secret scan
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
+
+  build:
+    runs-on: ubuntu-latest
+    needs: [lint, test]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Build package
+        run: uv build
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Secret scan
         run: |
           wget -qO- https://github.com/gitleaks/gitleaks/releases/download/v8.24.3/gitleaks_8.24.3_linux_x64.tar.gz | tar xz
-          ./gitleaks detect --source . --verbose
+          ./gitleaks detect --source . --verbose --config .gitleaks.toml
 
   build:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ Thumbs.db
 CLAUDE.md
 .claude/
 .specify/
+
+AUDIT-REPORT.md
+PROJECT-AUDIT.md

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,5 @@
+[allowlist]
+description = "CKAD exercise templates with fake secrets"
+paths = [
+    '''templates/q11-image/main\.go''',
+]

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -10,3 +10,7 @@ exams/ckad-simulation8/questions.md:generic-api-key:*
 exams/ckad-simulation8/solutions.md:generic-api-key:*
 exams/ckad-simulation9/questions.md:generic-api-key:*
 exams/ckad-simulation9/solutions.md:generic-api-key:*
+
+# Q11 image template (Go app with fake cipher for exercise)
+1839457ff9665242ee020a33030eec991db0b5e2:templates/q11-image/main.go:generic-api-key:16
+1839457ff9665242ee020a33030eec991db0b5e2:templates/q11-image/main.go:generic-api-key:21

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -10,7 +10,3 @@ exams/ckad-simulation8/questions.md:generic-api-key:*
 exams/ckad-simulation8/solutions.md:generic-api-key:*
 exams/ckad-simulation9/questions.md:generic-api-key:*
 exams/ckad-simulation9/solutions.md:generic-api-key:*
-
-# Q11 image template (Go app with fake cipher for exercise)
-1839457ff9665242ee020a33030eec991db0b5e2:templates/q11-image/main.go:generic-api-key:16
-1839457ff9665242ee020a33030eec991db0b5e2:templates/q11-image/main.go:generic-api-key:21


### PR DESCRIPTION
Description                                                                              
   
  Add two new jobs to the CI pipeline: security (pip-audit + gitleaks) and build (uv build 
  + artifact upload). The build job is gated by lint and test success.                  
                      
  Type of Change                            
                                                                
  - New feature (non-breaking change that adds functionality)

  Checklist

  - My code follows the project's style guidelines
  - I have run pre-commit run --all-files and fixed any issues
  - I have run ./tests/run-tests.sh and all tests pass
  - I have updated the documentation if needed
  - I have added tests for new functionality (if applicable)

  Testing Done

  - pre-commit run --all-files — tous les hooks passent (yamllint valide le YAML)
  - Pipeline a valider sur GitHub apres push

  Les sections Screenshots et Tests unitaires ne s'appliquent pas ici.