### PR TITLE
ci: add security and build jobs to pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- CI: `security` job with dependency audit (`pip-audit`) and secret scanning (`gitleaks`)
+- CI: `build` job with package build (`uv build`) and artifact upload
+- `.gitleaks.toml` config for path-based allowlist of exercise templates
+
 ### Changed
 
 ### Fixed


### PR DESCRIPTION
## Summary

- Add `security` job: dependency audit (`pip-audit`) + secret scanning (`gitleaks` binary)
- Add `build` job: package build (`uv build`) + artifact upload, gated by lint and test
- Add `.gitleaks.toml` with path-based allowlist for Q11 exercise template (fake cipher)
- Update CHANGELOG with new entries

## Test plan

- [x] Pre-commit hooks pass on all commits
- [ ] Verify `security` job passes (pip-audit + gitleaks)
- [ ] Verify `build` job produces wheel artifact
- [ ] Verify `lint` and `test` jobs still pass unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)