### PR TITLE
ci(pipeline): restructure CI into 3 ordered stages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
     branches: [main]
 
 jobs:
+  # ===========================================================================
+  # Stage 1: Lint & Format
+  # ===========================================================================
   lint:
     runs-on: ubuntu-latest
     steps:
@@ -26,8 +29,12 @@ jobs:
       - name: Run pre-commit
         run: uv run pre-commit run --all-files
 
+  # ===========================================================================
+  # Stage 2: Test & Security (run in parallel, after lint passes)
+  # ===========================================================================
   test:
     runs-on: ubuntu-latest
+    needs: [lint]
     steps:
       - uses: actions/checkout@v4
 
@@ -36,6 +43,7 @@ jobs:
 
   security:
     runs-on: ubuntu-latest
+    needs: [lint]
     steps:
       - uses: actions/checkout@v4
 
@@ -53,9 +61,12 @@ jobs:
           wget -qO- https://github.com/gitleaks/gitleaks/releases/download/v8.24.3/gitleaks_8.24.3_linux_x64.tar.gz | tar xz
           ./gitleaks detect --source . --verbose --config .gitleaks.toml
 
+  # ===========================================================================
+  # Stage 3: Build (after test & security pass)
+  # ===========================================================================
   build:
     runs-on: ubuntu-latest
-    needs: [lint, test]
+    needs: [test, security]
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary

- Enforce proper stage ordering in the CI pipeline: **lint → test + security → build**
- `test` and `security` now wait for `lint` to pass before running (previously all three ran in parallel)
- `build` now depends on both `test` and `security` succeeding (previously only lint + test)

```
Stage 1:  lint
            ↓
Stage 2:  test  ←→  security
            ↓         ↓
Stage 3:       build
```

Ref: AUDIT-REPORT.md — Action #3 (C4, C10-C11)

## Test plan

- [x] YAML valid (yamllint passes)
- [x] All pre-commit hooks pass
- [ ] CI pipeline runs with correct stage ordering on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)