### PR TITLE
chore(pre-commit): add check-added-large-files hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,6 +18,8 @@ repos:
       - id: check-toml
       - id: check-json
       - id: detect-private-key
+      - id: check-added-large-files
+        args: [--maxkb=500]
 
   # =============================================================================
   # Security


### PR DESCRIPTION
## Summary

- Add `check-added-large-files` hook to pre-commit with a **500KB threshold**
- Prevents accidental commits of large binaries or data files

Ref: AUDIT-REPORT.md — Action #4 (H7)

## Test plan

- [x] New hook passes on all existing files
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)