### PR TITLE
chore(deps): enrich Dependabot config with grouping and labels

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,13 +5,27 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+      day: "monday"
     commit-message:
       prefix: "chore(deps)"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+    groups:
+      dev-dependencies:
+        dependency-type: "development"
 
   # GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+      day: "monday"
     commit-message:
       prefix: "chore(ci)"
+    labels:
+      - "ci"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary

- **Group dev dependencies** (`pre-commit`) into a single PR instead of individual ones
- **Group all GitHub Actions** updates (`checkout`, `setup-python`, `setup-uv`, `upload-artifact`) into a single PR
- **Add labels** (`dependencies`, `ci`) for easier triage in the PR list
- **Pin schedule to Monday** for predictable update windows

No automerge — updates require manual review and testing.

Ref: AUDIT-REPORT.md — Action #5 (C52-C53)

## Test plan

- [x] YAML valid (yamllint passes)
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)