### PR TITLE
chore(typing): configure mypy and add pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -75,6 +75,13 @@ repos:
       - id: ruff-format
         exclude: (^\.venv/|^\.specify/)
 
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.15.0
+    hooks:
+      - id: mypy
+        exclude: (^\.venv/|^\.specify/)
+        additional_dependencies: [argcomplete>=3.0]
+
   # =============================================================================
   # Markdown
   # =============================================================================

--- a/ckad_dojo.py
+++ b/ckad_dojo.py
@@ -252,11 +252,11 @@ def run_script(
 
     try:
         if capture:
-            result = subprocess.run(cmd, capture_output=True, text=True, cwd=get_project_root())
-            return result.returncode, result.stdout, result.stderr
+            captured = subprocess.run(cmd, capture_output=True, text=True, cwd=get_project_root())
+            return captured.returncode, captured.stdout, captured.stderr
         else:
-            result = subprocess.run(cmd, cwd=get_project_root())
-            return result.returncode, "", ""
+            proc = subprocess.run(cmd, cwd=get_project_root())
+            return proc.returncode, "", ""
     except Exception as e:
         return 1, "", str(e)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,5 +65,17 @@ ignore = [
 quote-style = "double"
 indent-style = "space"
 
+[tool.mypy]
+python_version = "3.10"
+warn_return_any = true
+warn_unused_configs = true
+warn_redundant_casts = true
+warn_unused_ignores = true
+check_untyped_defs = true
+
+[[tool.mypy.overrides]]
+module = "argcomplete"
+ignore_missing_imports = true
+
 [dependency-groups]
-dev = ["pre-commit>=4.0"]
+dev = ["mypy>=1.0", "pre-commit>=4.0"]

--- a/web/server.py
+++ b/web/server.py
@@ -15,6 +15,7 @@ import sys
 import time
 import urllib.parse
 from pathlib import Path
+from typing import Any
 
 # Configuration
 PORT = 9090
@@ -26,7 +27,7 @@ PROJECT_DIR = SCRIPT_DIR.parent
 EXAMS_DIR = PROJECT_DIR / "exams"
 
 # Timer state (in-memory)
-timer_state = {
+timer_state: dict[str, Any] = {
     "start_time": None,
     "duration_minutes": 120,
     "exam_id": None,
@@ -42,7 +43,7 @@ timer_state = {
 shutdown_requested = False
 
 # Question flags state (in-memory)
-flagged_questions = set()
+flagged_questions: set[str] = set()
 
 # Scripts directory
 SCRIPTS_DIR = PROJECT_DIR / "scripts"
@@ -293,7 +294,7 @@ def run_scoring_script(exam_id: str | None = None) -> dict:
         }
 
 
-def parse_solutions_md(exam_id: str) -> list:
+def parse_solutions_md(exam_id: str) -> list[dict[str, object]]:
     """Parse solutions.md file and extract solutions"""
     solutions_file = EXAMS_DIR / exam_id / "solutions.md"
 
@@ -308,7 +309,7 @@ def parse_solutions_md(exam_id: str) -> list:
 
     lines = content.split("\n")
     current_solution = None
-    current_content = []
+    current_content: list[str] = []
 
     for line in lines:
         match = re.match(solution_pattern, line)
@@ -348,7 +349,7 @@ def parse_solutions_md(exam_id: str) -> list:
     return solutions
 
 
-def get_solution(exam_id: str, question_id: str) -> dict:
+def get_solution(exam_id: str, question_id: str) -> dict[str, object] | None:
     """Get a specific solution by question ID"""
     solutions = parse_solutions_md(exam_id)
     for solution in solutions:
@@ -379,7 +380,7 @@ def parse_questions_md(exam_id: str) -> list:
     # Find all question sections
     lines = content.split("\n")
     current_question = None
-    current_content = []
+    current_content: list[str] = []
 
     for line in lines:
         match = re.match(question_pattern, line)
@@ -771,7 +772,7 @@ class ExamHandler(http.server.SimpleHTTPRequestHandler):
             self.send_response(200)
             self.send_header("Content-Type", "application/json; charset=utf-8")
             self.send_header("Access-Control-Allow-Origin", "*")
-            self.send_header("Content-Length", len(response.encode("utf-8")))
+            self.send_header("Content-Length", str(len(response.encode("utf-8"))))
             self.end_headers()
             self.wfile.write(response.encode("utf-8"))
         except (BrokenPipeError, ConnectionResetError):


### PR DESCRIPTION
## Summary

- **Add `[tool.mypy]`** configuration in `pyproject.toml` with gradual typing settings (`check_untyped_defs`, `warn_return_any`, `warn_redundant_casts`, `warn_unused_ignores`)
- **Add `mirrors-mypy` pre-commit hook** (v1.15.0) with `argcomplete` dependency
- **Add `mypy` to dev dependencies**
- **Fix real type errors found by mypy**:
  - `get_solution()` return type: `dict` → `dict | None` (was silently returning `None`)
  - `send_header()` Content-Length: `int` → `str` (type mismatch)
  - Subprocess variable shadowing in `run_script()`
  - Missing type annotations on `flagged_questions`, `current_content` lists
  - `parse_solutions_md()` return type annotation
- **Annotate `timer_state`** as `dict[str, Any]` for mixed-type values (float, str, int, None, bool)

Ref: AUDIT-REPORT.md — Action #6 (P6, H4)

## Test plan

- [x] `mypy` passes on all 3 Python source files (0 errors)
- [x] `ruff check` passes
- [x] All pre-commit hooks pass (including new mypy hook)
- [x] All unit tests pass (5 suites, 52 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)