### PR TITLE
refactor: narrow except Exception to specific exception types

### DIFF
--- a/ckad_dojo.py
+++ b/ckad_dojo.py
@@ -209,7 +209,7 @@ def parse_exam_config(exam_id: str) -> dict[str, str] | None:
                 if match:
                     key, value = match.groups()
                     config[key] = value.strip("\"'")
-    except Exception:
+    except (OSError, ValueError):
         return None
 
     return config
@@ -257,7 +257,7 @@ def run_script(
         else:
             proc = subprocess.run(cmd, cwd=get_project_root())
             return proc.returncode, "", ""
-    except Exception as e:
+    except (OSError, subprocess.SubprocessError) as e:
         return 1, "", str(e)
 
 
@@ -296,7 +296,7 @@ def check_cluster_connectivity() -> bool:
             ["kubectl", "cluster-info"], capture_output=True, text=True, timeout=10
         )
         return result.returncode == 0
-    except Exception:
+    except (OSError, subprocess.SubprocessError):
         return False
 
 
@@ -1007,7 +1007,7 @@ def cmd_status(args) -> int:
             )
             print(f"  {exam_name}: {status}")
 
-        except Exception:
+        except (OSError, subprocess.SubprocessError):
             print(f"  {eid}: {color('UNKNOWN', Colors.YELLOW)}")
 
     print()

--- a/web/server.py
+++ b/web/server.py
@@ -93,7 +93,7 @@ def run_cleanup_script(exam_id: str | None = None) -> dict:
     except subprocess.TimeoutExpired:
         print("  [ERROR] Cleanup script timed out\n")
         return {"success": False, "error": "Cleanup script timed out"}
-    except Exception as e:
+    except (OSError, subprocess.SubprocessError) as e:
         print(f"  [ERROR] {e!s}\n")
         return {"success": False, "error": str(e)}
 
@@ -282,7 +282,7 @@ def run_scoring_script(exam_id: str | None = None) -> dict:
             "percentage": 0,
             "passed": False,
         }
-    except Exception as e:
+    except (OSError, subprocess.SubprocessError) as e:
         return {
             "success": False,
             "error": str(e),
@@ -762,7 +762,7 @@ class ExamHandler(http.server.SimpleHTTPRequestHandler):
             result = sock.connect_ex(("localhost", port))
             sock.close()
             return result == 0
-        except Exception:
+        except OSError:
             return False
 
     def send_json(self, data):


### PR DESCRIPTION
## Summary
- Replace all 7 broad `except Exception` handlers with targeted exception types
- `ckad_dojo.py`: 4 occurrences narrowed
- `web/server.py`: 3 occurrences narrowed

## Changes

| Location | Before | After | Rationale |
|----------|--------|-------|-----------|
| `parse_exam_config()` | `except Exception` | `except (OSError, ValueError)` | File I/O + encoding errors |
| `run_script()` | `except Exception as e` | `except (OSError, subprocess.SubprocessError) as e` | Command not found + subprocess errors |
| `check_cluster_connectivity()` | `except Exception` | `except (OSError, subprocess.SubprocessError)` | Same as above |
| `cmd_list()` kubectl check | `except Exception` | `except (OSError, subprocess.SubprocessError)` | Same as above |
| `run_cleanup()` | `except Exception as e` | `except (OSError, subprocess.SubprocessError) as e` | Already catches TimeoutExpired above |
| `run_scoring()` | `except Exception as e` | `except (OSError, subprocess.SubprocessError) as e` | Already catches TimeoutExpired above |
| `check_ttyd_status()` | `except Exception` | `except OSError` | Socket errors are all OSError subclasses |

## Test plan
- [x] All 57 pytest tests pass
- [x] mypy passes with no errors
- [x] ruff check passes
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)