### PR TITLE
docs: add architecture documentation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -103,5 +103,5 @@ repos:
           - "--skip"
           - ".venv,*.lock,*.json,CLAUDE.md,.specify,specs"
           - "--ignore-words-list"
-          - "nd,ans,aks,iam,ro,ngnix,uptodate"
+          - "nd,ans,aks,iam,ro,ngnix,uptodate,projet,vie,gere,methode,fonctions,ressources,reponse,reponses,fonction,verifie,defaut,dependance,dependances,independant"
         exclude: (^\.venv/|^\.specify/|^specs/|^\.claude/commands/)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 - CI: `security` job with dependency audit (`pip-audit`) and secret scanning (`gitleaks`)
 - CI: `build` job with package build (`uv build`) and artifact upload
+- CI: Python test step with pytest and coverage reporting
 - `.gitleaks.toml` config for path-based allowlist of exercise templates
+- Pre-commit: `check-added-large-files` hook (max 500KB)
+- Pre-commit: `mirrors-mypy` hook for Python type checking
+- Python unit tests: 57 tests covering `ckad_dojo.py`, `web/server.py`, `scripts/bump-version.py`
+- pytest + pytest-cov configuration in `pyproject.toml` (coverage threshold 30%)
+- mypy configuration with `explicit_package_bases` and gradual type checking
+- Dependabot: grouping, labels, and weekly Monday schedule
+- Architecture documentation (`docs/architecture.md`)
 
 ### Changed
 
+- CI: restructured pipeline into 3 ordered stages (lint -> test+security -> build)
+- Pre-commit: replaced flake8 with ruff (lint + format)
+- Ruff configuration in `pyproject.toml` with comprehensive rule selection
+- Narrowed all `except Exception` to specific exception types (`OSError`, `subprocess.SubprocessError`, `ValueError`)
+- Added type annotations to `web/server.py` and `ckad_dojo.py`
+- Codespell ignore list extended for French documentation support
+
 ### Fixed
 
+- `web/server.py`: `send_header` Content-Length passed as `str` instead of `int` (type bug)
+
 ### Removed
+
+- `.flake8` configuration file (replaced by ruff in `pyproject.toml`)
 
 ## [1.7.0] - 2026-01-26
 

--- a/docs/architecture.en.md
+++ b/docs/architecture.en.md
@@ -1,0 +1,259 @@
+# Architecture
+
+> **Prerequisites**: Read the README.md for the project's functional context.
+
+## Mental Model
+
+```
+                          User
+                       /        \
+                      /          \
+              [Python CLI]    [Browser]
+              ckad_dojo.py        |
+                   |         web/server.py ── index.html + app.js
+                   |              |
+              subprocess      subprocess
+                   |              |
+              scripts/ckad-*.sh ◄─┘
+                   |
+            ┌──────┼──────┐
+            │      │      │
+         kubectl  helm  docker
+            │
+      Kubernetes Cluster
+```
+
+The project follows a **layered architecture**:
+
+1. **Presentation layer**: Interactive Python CLI or web interface
+2. **Orchestration layer**: Bash scripts that execute the exam lifecycle
+3. **Infrastructure layer**: kubectl, helm, docker for K8s operations
+
+------
+
+## Main Components
+
+### Python CLI (`ckad_dojo.py`)
+
+Main entry point. Provides an interactive menu and subcommands
+(`exam start`, `score`, `cleanup`, `list`, `info`, `status`, `completion`).
+
+It acts as a **lightweight orchestrator**: it contains no business logic but
+delegates all operations to Bash scripts via `subprocess.run()`.
+
+```
+ckad_dojo.py
+  ├── Interactive menu (no-argument mode)
+  ├── argparse subcommands + argcomplete
+  └── run_script() ──> scripts/ckad-*.sh
+```
+
+### Web Server (`web/server.py`)
+
+Python standard library HTTP server (`http.server`) with no external framework.
+Launched by `ckad-exam.sh` in web mode. Listens on `localhost:9090`.
+
+**Responsibilities**:
+
+- Serves static files (`index.html`, `app.js`, `style.css`)
+- Exposes a JSON REST API for the frontend
+- Manages the exam timer in memory
+- Runs scoring and cleanup via subprocess
+
+**Main endpoints**:
+
+| Method | Route | Description |
+|--------|-------|-------------|
+| GET | `/api/exams` | List available exams |
+| GET | `/api/exam/{id}/questions` | Questions parsed from `questions.md` |
+| GET | `/api/exam/{id}/config` | Exam configuration |
+| GET | `/api/exam/{id}/solutions` | Solutions (post-exam) |
+| GET | `/api/timer` | Timer state |
+| POST | `/api/score` | Stop timer + run scoring |
+| POST | `/api/cleanup` | Run cleanup |
+| POST | `/api/shutdown` | Graceful server shutdown |
+
+### Frontend (`web/`)
+
+Vanilla JavaScript application (ES6+) with no framework.
+
+- **Markdown rendering**: `marked.js` + `highlight.js` for questions and solutions
+- **Icons**: Lucide
+- **Interface**: question panel (left) + embedded ttyd terminal (right, iframe)
+- **Features**: question navigation, timer, flags, dark/light theme, keyboard shortcuts, score modal with per-criteria details
+
+### Bash Scripts (`scripts/`)
+
+Operational core of the project. Four main scripts + shared libraries.
+
+```
+scripts/
+  ├── ckad-setup.sh          # K8s environment preparation
+  ├── ckad-exam.sh           # Exam launcher (web or terminal)
+  ├── ckad-score.sh          # Answer evaluation
+  ├── ckad-cleanup.sh        # Environment cleanup
+  └── lib/
+      ├── common.sh          # Utilities (colors, kubectl helpers, ttyd, state)
+      ├── setup-functions.sh # Setup and cleanup functions
+      ├── timer.sh           # File-based timer (PID, state, countdown)
+      └── banner.sh          # ASCII banner for the terminal
+```
+
+------
+
+## Exam Lifecycle
+
+```
+ 1. SETUP                2. EXAM                 3. SCORE               4. CLEANUP
+ ckad-setup.sh           ckad-exam.sh            ckad-score.sh          ckad-cleanup.sh
+ ┌──────────────┐        ┌──────────────┐        ┌──────────────┐       ┌──────────────┐
+ │ Create NS    │        │ Start ttyd   │        │ Load         │       │ Stop timer   │
+ │ Deploy       │───────>│ Start        │───────>│  scoring-    │──────>│ Uninstall    │
+ │  manifests   │        │  server.py   │        │  functions   │       │  Helm        │
+ │ Copy         │        │ Open         │        │ Evaluate     │       │ Delete NS    │
+ │  templates   │        │  browser     │        │  score_q1()  │       │ Delete PV    │
+ │ Registry     │        │              │        │  ...         │       │ Remove       │
+ │ Helm charts  │        │              │        │  score_qN()  │       │  registry    │
+ │ Post-setup   │        │              │        │ Display      │       │ Clean up     │
+ │              │        │              │        │  results     │       │  Docker      │
+ └──────────────┘        └──────────────┘        └──────────────┘       └──────────────┘
+        │                                                                       │
+        └── State saved in /tmp/ckad-dojo/active-exam.state ────────────────────┘
+```
+
+------
+
+## Exam Structure
+
+Each exam is a self-contained directory under `exams/{exam-id}/`:
+
+```
+exams/ckad-simulation1/
+  ├── exam.conf              # Configuration (duration, points, namespaces, options)
+  ├── questions.md           # Questions in Markdown with metadata table
+  ├── solutions.md           # Solutions for post-exam review
+  ├── scoring-functions.sh   # Bash functions: score_q1(), score_q2(), ...
+  ├── manifests/
+  │   └── setup/
+  │       ├── namespaces.yaml    # Namespace definitions
+  │       └── *.yaml             # Pre-existing K8s resources
+  └── templates/
+      ├── q01-file.yaml          # Files copied to exam/course/N/
+      └── q11-image/             # Directories (Dockerfile, etc.)
+```
+
+**Key `exam.conf` variables**:
+
+| Variable | Description |
+|----------|-------------|
+| `EXAM_NAME` | Display name |
+| `EXAM_DURATION` | Duration in minutes |
+| `TOTAL_QUESTIONS` / `TOTAL_POINTS` | Exam dimensions |
+| `PASSING_PERCENTAGE` | Pass threshold (default 66%) |
+| `EXAM_NAMESPACES=()` | Array of namespaces to create |
+| `HELM_RELEASES=()` | Helm releases to install |
+| `ALLOW_TIMER_PAUSE` | Allow timer pause |
+| `ALLOW_HINTS` | Allow hints |
+| `DOJO_NAME` / `DOJO_EMOJI` | Dojo thematic identity |
+
+------
+
+## Scoring Mechanism
+
+```
+scoring-functions.sh                    web/server.py
+┌─────────────────────┐                ┌──────────────────────┐
+│ score_q1() {        │   stdout       │ run_scoring_script() │
+│   # kubectl checks  │ ──────────────>│   parse output:      │
+│   echo "2/3"        │                │   - regex Q(\d+)     │
+│   echo "DETAILS:..."│                │   - regex TOTAL      │
+│ }                   │                │   - parse DETAILS:   │
+└─────────────────────┘                │   return JSON        │
+                                       └──────────────────────┘
+```
+
+Each `score_qN()` function:
+
+1. Checks K8s resources via helpers (`resource_exists`, `get_resource_field`)
+2. Prints pass/fail markers (checkmark/cross) per criterion
+3. Returns `score/max_points` on stdout
+4. Returns `DETAILS:item1. item2.` for criteria details
+
+The web server parses this output with regex and builds a structured JSON
+response for the interface.
+
+------
+
+## External Integrations
+
+| Tool | Role | Usage |
+|------|------|-------|
+| **kubectl** | K8s operations | Setup (create/apply), scoring (get/describe), cleanup (delete) |
+| **helm** | Helm charts | Install releases for Helm-related questions |
+| **docker** | Local registry | `registry:2` on `localhost:5000` for build questions |
+| **ttyd** | Web terminal | Embedded in the interface via iframe on port 7682 |
+| **uv** | Python manager | Runs the server, tests, and linting |
+
+------
+
+## Test Infrastructure
+
+### Bash Tests (`tests/`)
+
+Custom test framework (`test-framework.sh`) with assertions:
+
+```
+tests/
+  ├── run-tests.sh            # Runner: executes all test-*.sh files
+  ├── test-framework.sh       # Assertions (assert_true, assert_equals, ...)
+  ├── test-common.sh          # Tests for scripts/lib/common.sh
+  ├── test-setup-functions.sh # Tests for scripts/lib/setup-functions.sh
+  ├── test-timer.sh           # Tests for scripts/lib/timer.sh
+  ├── test-banner.sh          # Tests for scripts/lib/banner.sh
+  └── test-scoring.sh         # Tests for scoring functions
+```
+
+### Python Tests (`tests/python/`)
+
+57 unit tests via pytest + pytest-cov:
+
+| Module | Coverage |
+|--------|----------|
+| `ckad_dojo.py` | CLI, config parsing, exam discovery |
+| `web/server.py` | Parsing, config, questions, solutions |
+| `scripts/bump-version.py` | Validation, version reading, file update |
+
+### CI Pipeline (`.github/workflows/ci.yml`)
+
+```
+  Stage 1          Stage 2              Stage 3
+ ┌──────┐     ┌──────┐  ┌──────┐     ┌──────┐
+ │ Lint │────>│ Test │  │Secu. │────>│Build │
+ │      │     │      │  │      │     │      │
+ └──────┘     └──────┘  └──────┘     └──────┘
+                 │           │
+              parallel    parallel
+```
+
+- **Lint**: `pre-commit run --all-files` (ruff, shellcheck, mypy, markdownlint, etc.)
+- **Test**: Bash tests + pytest with coverage
+- **Security**: `pip-audit` + `gitleaks`
+- **Build**: `uv build` + artifact upload
+
+------
+
+## Technical Decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| Python standard library only (server) | Zero external dependencies, simple deployment |
+| Bash for business logic | Direct interaction with kubectl/helm/docker without abstraction layer |
+| Python CLI as orchestrator | Ergonomics (argparse, completion, interactive menu) without duplicating logic |
+| In-memory timer (server) | Simplicity, no persistence needed for an ephemeral exam |
+| Self-contained exams | Each dojo is an independent directory, making it easy to add new exams |
+| Vanilla JS frontend | No build step, direct loading, minimal CDN dependencies |
+
+------
+
+> **Document created**: 2026-02-17
+> **Version**: 1.0

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,259 @@
+# Architecture
+
+> **Prerequis** : Lecture du README.md pour le contexte fonctionnel du projet.
+
+## Mental Model
+
+```
+                        Utilisateur
+                       /           \
+                      /             \
+              [CLI Python]      [Navigateur]
+              ckad_dojo.py          |
+                   |           web/server.py ── index.html + app.js
+                   |                |
+              subprocess        subprocess
+                   |                |
+              scripts/ckad-*.sh ◄───┘
+                   |
+            ┌──────┼──────┐
+            │      │      │
+         kubectl  helm  docker
+            │
+      Cluster Kubernetes
+```
+
+Le projet suit une architecture en **couches** :
+
+1. **Couche presentation** : CLI Python interactive ou interface web
+2. **Couche orchestration** : scripts Bash qui executent le cycle de vie
+3. **Couche infrastructure** : kubectl, helm, docker pour les operations K8s
+
+------
+
+## Composants principaux
+
+### CLI Python (`ckad_dojo.py`)
+
+Point d'entree principal. Fournit un menu interactif et des sous-commandes
+(`exam start`, `score`, `cleanup`, `list`, `info`, `status`, `completion`).
+
+C'est un **orchestrateur leger** : il ne contient pas de logique metier mais
+delegue toutes les operations aux scripts Bash via `subprocess.run()`.
+
+```
+ckad_dojo.py
+  ├── Menu interactif (mode sans arguments)
+  ├── Sous-commandes argparse + argcomplete
+  └── run_script() ──> scripts/ckad-*.sh
+```
+
+### Serveur web (`web/server.py`)
+
+Serveur HTTP Python standard library (`http.server`) sans framework externe.
+Lance par `ckad-exam.sh` en mode web. Ecoute sur `localhost:9090`.
+
+**Roles** :
+
+- Sert les fichiers statiques (`index.html`, `app.js`, `style.css`)
+- Expose une API REST JSON pour le frontend
+- Gere le timer d'examen en memoire
+- Execute le scoring et le cleanup via subprocess
+
+**Endpoints principaux** :
+
+| Methode | Route | Description |
+|---------|-------|-------------|
+| GET | `/api/exams` | Liste des examens disponibles |
+| GET | `/api/exam/{id}/questions` | Questions parsees depuis `questions.md` |
+| GET | `/api/exam/{id}/config` | Configuration de l'examen |
+| GET | `/api/exam/{id}/solutions` | Solutions (post-examen) |
+| GET | `/api/timer` | Etat du timer |
+| POST | `/api/score` | Arrete le timer + lance le scoring |
+| POST | `/api/cleanup` | Execute le nettoyage |
+| POST | `/api/shutdown` | Arret du serveur |
+
+### Frontend (`web/`)
+
+Application JavaScript vanilla (ES6+) sans framework.
+
+- **Rendu Markdown** : `marked.js` + `highlight.js` pour les questions et solutions
+- **Icones** : Lucide
+- **Interface** : panneau de questions (gauche) + terminal ttyd embarque (droite, iframe)
+- **Fonctionnalites** : navigation entre questions, timer, flags, theme sombre/clair, raccourcis clavier, modale de score avec details par critere
+
+### Scripts Bash (`scripts/`)
+
+Coeur operationnel du projet. Quatre scripts principaux + bibliotheques partagees.
+
+```
+scripts/
+  ├── ckad-setup.sh          # Preparation de l'environnement K8s
+  ├── ckad-exam.sh           # Lancement de l'examen (web ou terminal)
+  ├── ckad-score.sh          # Evaluation des reponses
+  ├── ckad-cleanup.sh        # Nettoyage de l'environnement
+  └── lib/
+      ├── common.sh          # Utilitaires (couleurs, helpers kubectl, ttyd, etat)
+      ├── setup-functions.sh # Fonctions de setup et cleanup
+      ├── timer.sh           # Timer base sur fichiers (PID, etat, countdown)
+      └── banner.sh          # Banniere ASCII pour le terminal
+```
+
+------
+
+## Cycle de vie d'un examen
+
+```
+ 1. SETUP                2. EXAM                 3. SCORE               4. CLEANUP
+ ckad-setup.sh           ckad-exam.sh            ckad-score.sh          ckad-cleanup.sh
+ ┌──────────────┐        ┌──────────────┐        ┌──────────────┐       ┌──────────────┐
+ │ Creer NS     │        │ Lancer ttyd  │        │ Charger      │       │ Stop timer   │
+ │ Deployer     │───────>│ Lancer       │───────>│  scoring-    │──────>│ Uninstall    │
+ │  manifests   │        │  server.py   │        │  functions   │       │  Helm        │
+ │ Copier       │        │ Ouvrir       │        │ Evaluer      │       │ Supprimer NS │
+ │  templates   │        │  navigateur  │        │  score_q1()  │       │ Supprimer PV │
+ │ Registry     │        │              │        │  ...         │       │ Supprimer    │
+ │ Helm charts  │        │              │        │  score_qN()  │       │  registry    │
+ │ Post-setup   │        │              │        │ Afficher     │       │ Nettoyer     │
+ │              │        │              │        │  resultats   │       │  Docker      │
+ └──────────────┘        └──────────────┘        └──────────────┘       └──────────────┘
+        │                                                                       │
+        └── Etat sauvegarde dans /tmp/ckad-dojo/active-exam.state ──────────────┘
+```
+
+------
+
+## Structure d'un examen
+
+Chaque examen est un repertoire autonome sous `exams/{exam-id}/` :
+
+```
+exams/ckad-simulation1/
+  ├── exam.conf              # Configuration (duree, points, namespaces, options)
+  ├── questions.md           # Questions en Markdown avec table de metadonnees
+  ├── solutions.md           # Solutions pour la revue post-examen
+  ├── scoring-functions.sh   # Fonctions Bash : score_q1(), score_q2(), ...
+  ├── manifests/
+  │   └── setup/
+  │       ├── namespaces.yaml    # Definitions des namespaces
+  │       └── *.yaml             # Ressources K8s pre-existantes
+  └── templates/
+      ├── q01-file.yaml          # Fichiers copies dans exam/course/N/
+      └── q11-image/             # Repertoires (Dockerfile, etc.)
+```
+
+**Variables cles de `exam.conf`** :
+
+| Variable | Description |
+|----------|-------------|
+| `EXAM_NAME` | Nom affiche |
+| `EXAM_DURATION` | Duree en minutes |
+| `TOTAL_QUESTIONS` / `TOTAL_POINTS` | Dimensions de l'examen |
+| `PASSING_PERCENTAGE` | Seuil de reussite (defaut 66%) |
+| `EXAM_NAMESPACES=()` | Tableau des namespaces a creer |
+| `HELM_RELEASES=()` | Releases Helm a installer |
+| `ALLOW_TIMER_PAUSE` | Autoriser la pause du timer |
+| `ALLOW_HINTS` | Autoriser les indices |
+| `DOJO_NAME` / `DOJO_EMOJI` | Identite thematique du dojo |
+
+------
+
+## Mecanisme de scoring
+
+```
+scoring-functions.sh                    web/server.py
+┌─────────────────────┐                ┌──────────────────────┐
+│ score_q1() {        │   stdout       │ run_scoring_script() │
+│   # kubectl checks  │ ──────────────>│   parse output:      │
+│   echo "2/3"        │                │   - regex Q(\d+)     │
+│   echo "DETAILS:..."│                │   - regex TOTAL      │
+│ }                   │                │   - parse DETAILS:   │
+└─────────────────────┘                │   return JSON        │
+                                       └──────────────────────┘
+```
+
+Chaque fonction `score_qN()` :
+
+1. Verifie les ressources K8s via des helpers (`resource_exists`, `get_resource_field`)
+2. Affiche des marqueurs pass/fail (checkmark/cross) par critere
+3. Retourne `score/max_points` sur stdout
+4. Retourne `DETAILS:item1. item2.` pour le detail des criteres
+
+Le serveur web parse cette sortie avec des regex et construit une reponse JSON
+structuree pour l'interface.
+
+------
+
+## Integrations externes
+
+| Outil | Role | Utilisation |
+|-------|------|-------------|
+| **kubectl** | Operations K8s | Setup (create/apply), scoring (get/describe), cleanup (delete) |
+| **helm** | Charts Helm | Installation de releases pour les questions Helm |
+| **docker** | Registry local | `registry:2` sur `localhost:5000` pour les questions de build |
+| **ttyd** | Terminal web | Embarque dans l'interface via iframe sur le port 7682 |
+| **uv** | Gestionnaire Python | Execute le serveur, les tests, le linting |
+
+------
+
+## Infrastructure de tests
+
+### Tests Bash (`tests/`)
+
+Framework de test custom (`test-framework.sh`) avec assertions :
+
+```
+tests/
+  ├── run-tests.sh            # Runner : execute tous les test-*.sh
+  ├── test-framework.sh       # Assertions (assert_true, assert_equals, ...)
+  ├── test-common.sh          # Tests de scripts/lib/common.sh
+  ├── test-setup-functions.sh # Tests de scripts/lib/setup-functions.sh
+  ├── test-timer.sh           # Tests de scripts/lib/timer.sh
+  ├── test-banner.sh          # Tests de scripts/lib/banner.sh
+  └── test-scoring.sh         # Tests des fonctions de scoring
+```
+
+### Tests Python (`tests/python/`)
+
+57 tests unitaires via pytest + pytest-cov :
+
+| Module | Couverture |
+|--------|------------|
+| `ckad_dojo.py` | CLI, parsing config, decouverte d'examens |
+| `web/server.py` | Parsing, config, questions, solutions |
+| `scripts/bump-version.py` | Validation, lecture version, mise a jour |
+
+### Pipeline CI (`.github/workflows/ci.yml`)
+
+```
+  Stage 1          Stage 2              Stage 3
+ ┌──────┐     ┌──────┐  ┌──────┐     ┌──────┐
+ │ Lint │────>│ Test │  │Secu. │────>│Build │
+ │      │     │      │  │      │     │      │
+ └──────┘     └──────┘  └──────┘     └──────┘
+                 │           │
+              parallel    parallel
+```
+
+- **Lint** : `pre-commit run --all-files` (ruff, shellcheck, mypy, markdownlint, etc.)
+- **Test** : tests Bash + pytest avec couverture
+- **Security** : `pip-audit` + `gitleaks`
+- **Build** : `uv build` + upload des artefacts
+
+------
+
+## Decisions techniques
+
+| Decision | Justification |
+|----------|---------------|
+| Python standard library uniquement (serveur) | Zero dependance externe, deploiement simple |
+| Bash pour la logique metier | Interaction directe avec kubectl/helm/docker sans couche d'abstraction |
+| CLI Python comme orchestrateur | Ergonomie (argparse, completion, menu interactif) sans dupliquer la logique |
+| Timer en memoire (serveur) | Simplicite, pas de persistence necessaire pour un examen ephemere |
+| Examens auto-contenus | Chaque dojo est un repertoire independant, facilitant l'ajout de nouveaux examens |
+| Frontend vanilla JS | Pas de build step, chargement direct, dependances CDN minimales |
+
+------
+
+> **Document cree le** : 2026-02-17
+> **Version** : 1.0


### PR DESCRIPTION
## Summary
- Add `docs/architecture.md` covering the full system architecture
- Add French words to codespell ignore list to support French documentation

## Document contents
- **Mental model** : schema ASCII de l'architecture en couches
- **Composants principaux** : CLI Python, serveur web, frontend, scripts Bash
- **Cycle de vie d'un examen** : setup -> exam -> score -> cleanup
- **Structure d'un examen** : exam.conf, questions.md, solutions.md, scoring-functions.sh, manifests, templates
- **Mecanisme de scoring** : flux de donnees entre scoring-functions.sh et server.py
- **Integrations externes** : kubectl, helm, docker, ttyd, uv
- **Infrastructure de tests** : tests Bash + pytest + CI pipeline
- **Decisions techniques** : justification des choix architecturaux

## Test plan
- [x] markdownlint passes
- [x] codespell passes (French words added to ignore list)
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)