### PR TITLE
fix: align ckad-exam.sh default exam with common.sh source of truth

### DIFF
--- a/scripts/ckad-exam.sh
+++ b/scripts/ckad-exam.sh
@@ -12,8 +12,6 @@ PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 source "$SCRIPT_DIR/lib/common.sh"
 source "$SCRIPT_DIR/lib/timer.sh"
 
-# Default exam
-DEFAULT_EXAM="ckad-simulation1"
 EXAMS_DIR="$PROJECT_DIR/exams"
 
 # Web server settings
@@ -436,7 +434,7 @@ cleanup_web() {
 
 # Start web interface
 start_web() {
-	local exam_id=${1:-$DEFAULT_EXAM}
+	local exam_id=${1:-$DEFAULT_EXAM_ID}
 	local skip_confirm=$2
 	local start_question=${3:-1}
 	local no_terminal=$4
@@ -573,7 +571,7 @@ start_web() {
 
 # Start exam session (terminal mode)
 start_exam() {
-	local exam_id=${1:-$DEFAULT_EXAM}
+	local exam_id=${1:-$DEFAULT_EXAM_ID}
 	local skip_confirm=$2
 	local no_timer=$3
 	local start_question=${4:-1}


### PR DESCRIPTION
## Summary

- **Remove redundant `DEFAULT_EXAM="ckad-simulation1"`** from `ckad-exam.sh` — it shadowed the shared `DEFAULT_EXAM_ID="ckad-simulation2"` defined in `common.sh`
- **Replace `$DEFAULT_EXAM` → `$DEFAULT_EXAM_ID`** in `start_web()` and `start_exam()` so all 4 scripts (`ckad-exam`, `ckad-setup`, `ckad-score`, `ckad-cleanup`) share the same default

### Before (bug)
```bash
./scripts/ckad-exam.sh web   # → ckad-simulation1
./scripts/ckad-score.sh      # → ckad-simulation2  ← mismatch
./scripts/ckad-cleanup.sh    # → ckad-simulation2  ← mismatch
```

### After (fix)
```bash
./scripts/ckad-exam.sh web   # → ckad-simulation2
./scripts/ckad-score.sh      # → ckad-simulation2  ✓
./scripts/ckad-cleanup.sh    # → ckad-simulation2  ✓
```

## Test plan

- [ ] Run `./scripts/ckad-exam.sh web` without `-e` flag → verify it uses `ckad-simulation2`
- [ ] Run `./scripts/ckad-score.sh` without `-e` flag → verify same exam
- [ ] Run `./scripts/ckad-exam.sh web -e ckad-simulation1` → verify explicit flag still works
- [ ] ShellCheck passes (validated by pre-commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)