### PR TITLE
fix: harmonize exam selection across all CLI scripts

### DIFF
--- a/scripts/ckad-cleanup.sh
+++ b/scripts/ckad-cleanup.sh
@@ -18,7 +18,7 @@ show_help() {
 	echo ""
 	echo "OPTIONS:"
 	echo "  -h, --help         Show this help message"
-	echo "  -e, --exam EXAM    Select exam to clean up (default: $DEFAULT_EXAM_ID)"
+	echo "  -e, --exam EXAM    Select exam to clean up (default: active exam or interactive)"
 	echo "  -y, --yes          Skip confirmation prompt"
 	echo "  --keep-registry    Keep the local Docker registry running"
 	echo "  --keep-dirs        Keep the exam directory structure"
@@ -102,10 +102,10 @@ main() {
 		active_exam=$(get_active_exam)
 		if [ -n "$active_exam" ]; then
 			SELECTED_EXAM="$active_exam"
-			echo -e "${CYAN}Auto-detected active exam: $SELECTED_EXAM${NC}"
+			echo -e "${CYAN}Active exam detected: $SELECTED_EXAM${NC}"
 		else
-			SELECTED_EXAM="$DEFAULT_EXAM_ID"
-			echo -e "${YELLOW}No active exam detected, using default: $SELECTED_EXAM${NC}"
+			echo -e "${YELLOW}No active exam detected.${NC}"
+			select_exam_interactive
 		fi
 	fi
 

--- a/scripts/ckad-cleanup.sh
+++ b/scripts/ckad-cleanup.sh
@@ -99,7 +99,7 @@ main() {
 	# Auto-detect active exam if not specified
 	if [ "$EXAM_SPECIFIED" = false ]; then
 		local active_exam
-		active_exam=$(get_active_exam)
+		active_exam=$(get_active_exam) || true
 		if [ -n "$active_exam" ]; then
 			SELECTED_EXAM="$active_exam"
 			echo -e "${CYAN}Active exam detected: $SELECTED_EXAM${NC}"

--- a/scripts/ckad-exam.sh
+++ b/scripts/ckad-exam.sh
@@ -12,8 +12,6 @@ PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 source "$SCRIPT_DIR/lib/common.sh"
 source "$SCRIPT_DIR/lib/timer.sh"
 
-# Default exam
-DEFAULT_EXAM="ckad-simulation1"
 EXAMS_DIR="$PROJECT_DIR/exams"
 
 # Web server settings
@@ -436,7 +434,7 @@ cleanup_web() {
 
 # Start web interface
 start_web() {
-	local exam_id=${1:-$DEFAULT_EXAM}
+	local exam_id=${1:-$DEFAULT_EXAM_ID}
 	local skip_confirm=$2
 	local start_question=${3:-1}
 	local no_terminal=$4
@@ -573,7 +571,7 @@ start_web() {
 
 # Start exam session (terminal mode)
 start_exam() {
-	local exam_id=${1:-$DEFAULT_EXAM}
+	local exam_id=${1:-$DEFAULT_EXAM_ID}
 	local skip_confirm=$2
 	local no_timer=$3
 	local start_question=${4:-1}

--- a/scripts/ckad-exam.sh
+++ b/scripts/ckad-exam.sh
@@ -89,61 +89,6 @@ list_exams() {
 	done
 }
 
-# Get array of available exams
-get_available_exams() {
-	local exams=()
-	for exam_dir in "$EXAMS_DIR"/*/; do
-		if [ -d "$exam_dir" ] && [ -f "$exam_dir/exam.conf" ]; then
-			exams+=("$(basename "$exam_dir")")
-		fi
-	done
-	echo "${exams[@]}"
-}
-
-# Interactive exam selection
-select_exam_interactive() {
-	local exams=($(get_available_exams))
-	local num_exams=${#exams[@]}
-
-	if [ $num_exams -eq 0 ]; then
-		print_error "No exams found in $EXAMS_DIR"
-		exit 1
-	fi
-
-	echo ""
-	echo -e "${BLUE}╔═══════════════════════════════════════════════════════════════════╗${NC}"
-	echo -e "${BLUE}║${NC}                     SELECT AN EXAM TO START                       ${BLUE}║${NC}"
-	echo -e "${BLUE}╠═══════════════════════════════════════════════════════════════════╣${NC}"
-	echo -e "${BLUE}║${NC}"
-
-	local i=1
-	for exam_id in "${exams[@]}"; do
-		source "$EXAMS_DIR/$exam_id/exam.conf"
-		printf "${BLUE}║${NC}  ${CYAN}%d)${NC} %-20s - %s\n" $i "$exam_id" "$EXAM_NAME"
-		printf "${BLUE}║${NC}     Duration: %d min | Questions: %d | Points: %d\n" \
-			"$EXAM_DURATION" "$TOTAL_QUESTIONS" "$TOTAL_POINTS"
-		echo -e "${BLUE}║${NC}"
-		((i++))
-	done
-
-	echo -e "${BLUE}╚═══════════════════════════════════════════════════════════════════╝${NC}"
-	echo ""
-
-	local selection
-	while true; do
-		read -r -p "Select an exam: " selection
-		if [[ "$selection" =~ ^[0-9]+$ ]] && [ "$selection" -ge 1 ] && [ "$selection" -le "$num_exams" ]; then
-			SELECTED_EXAM="${exams[$((selection - 1))]}"
-			break
-		else
-			echo -e "${RED}Invalid selection. Please enter a valid exam number.${NC}"
-		fi
-	done
-
-	echo ""
-	echo -e "${GREEN}Selected:${NC} $SELECTED_EXAM"
-}
-
 # Detect if another exam's resources exist in the cluster
 detect_existing_exam_resources() {
 	local target_exam=$1
@@ -434,7 +379,7 @@ cleanup_web() {
 
 # Start web interface
 start_web() {
-	local exam_id=${1:-$DEFAULT_EXAM_ID}
+	local exam_id=$1
 	local skip_confirm=$2
 	local start_question=${3:-1}
 	local no_terminal=$4
@@ -571,7 +516,7 @@ start_web() {
 
 # Start exam session (terminal mode)
 start_exam() {
-	local exam_id=${1:-$DEFAULT_EXAM_ID}
+	local exam_id=$1
 	local skip_confirm=$2
 	local no_timer=$3
 	local start_question=${4:-1}

--- a/scripts/ckad-score.sh
+++ b/scripts/ckad-score.sh
@@ -16,13 +16,13 @@ show_help() {
 	echo ""
 	echo "OPTIONS:"
 	echo "  -h, --help         Show this help message"
-	echo "  -e, --exam EXAM    Select exam to score (default: $DEFAULT_EXAM_ID)"
+	echo "  -e, --exam EXAM    Select exam to score (default: active exam)"
 	echo "  -q, --question N   Score a specific question (1-22, p1, p2)"
 	echo "  -s, --summary      Show summary only (no details)"
 	echo "  --list             List available exams"
 	echo ""
 	echo "EXAMPLES:"
-	echo "  $(basename "$0")                      # Score all questions (default exam)"
+	echo "  $(basename "$0")                      # Score active exam"
 	echo "  $(basename "$0") -e ckad-simulation1  # Score specific exam"
 	echo "  $(basename "$0") -q 5                 # Score only question 5"
 	echo "  $(basename "$0") -s                   # Show summary only"
@@ -48,7 +48,7 @@ list_exams() {
 # Parse arguments
 SPECIFIC_QUESTION=""
 SUMMARY_ONLY=false
-SELECTED_EXAM="$DEFAULT_EXAM_ID"
+SELECTED_EXAM=""
 
 while [[ $# -gt 0 ]]; do
 	case $1 in
@@ -79,6 +79,18 @@ while [[ $# -gt 0 ]]; do
 		;;
 	esac
 done
+
+# Resolve exam: use active exam or fail explicitly
+if [ -z "$SELECTED_EXAM" ]; then
+	active_exam=$(get_active_exam)
+	if [ -n "$active_exam" ]; then
+		SELECTED_EXAM="$active_exam"
+		echo -e "${CYAN}Active exam detected: $SELECTED_EXAM${NC}"
+	else
+		print_error "No active exam detected. Use -e to specify an exam, or --list to see available exams."
+		exit 1
+	fi
+fi
 
 # Main scoring function
 main() {

--- a/scripts/ckad-score.sh
+++ b/scripts/ckad-score.sh
@@ -82,7 +82,7 @@ done
 
 # Resolve exam: use active exam or fail explicitly
 if [ -z "$SELECTED_EXAM" ]; then
-	active_exam=$(get_active_exam)
+	active_exam=$(get_active_exam) || true
 	if [ -n "$active_exam" ]; then
 		SELECTED_EXAM="$active_exam"
 		echo -e "${CYAN}Active exam detected: $SELECTED_EXAM${NC}"

--- a/scripts/ckad-setup.sh
+++ b/scripts/ckad-setup.sh
@@ -17,7 +17,7 @@ show_help() {
 	echo ""
 	echo "OPTIONS:"
 	echo "  -h, --help         Show this help message"
-	echo "  -e, --exam EXAM    Select exam to set up (default: $DEFAULT_EXAM_ID)"
+	echo "  -e, --exam EXAM    Select exam to set up (default: interactive selection)"
 	echo "  -q, --quiet        Suppress non-essential output"
 	echo "  --skip-registry    Skip local Docker registry setup"
 	echo "  --list             List available exams"
@@ -33,7 +33,7 @@ show_help() {
 	echo "The script is idempotent - safe to run multiple times."
 	echo ""
 	echo "EXAMPLES:"
-	echo "  $(basename "$0")                          # Setup default exam"
+	echo "  $(basename "$0")                          # Interactive exam selection"
 	echo "  $(basename "$0") -e ckad-simulation1      # Setup specific exam"
 	echo "  $(basename "$0") --list                   # List available exams"
 }
@@ -58,7 +58,7 @@ list_exams() {
 # Parse arguments
 QUIET=false
 SKIP_REGISTRY=false
-SELECTED_EXAM="$DEFAULT_EXAM_ID"
+SELECTED_EXAM=""
 
 while [[ $# -gt 0 ]]; do
 	case $1 in
@@ -89,6 +89,11 @@ while [[ $# -gt 0 ]]; do
 		;;
 	esac
 done
+
+# Interactive exam selection if not specified
+if [ -z "$SELECTED_EXAM" ]; then
+	select_exam_interactive
+fi
 
 # Main setup function
 main() {

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -16,9 +16,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 EXAMS_DIR="$PROJECT_DIR/exams"
 
-# Default exam configuration
-DEFAULT_EXAM_ID="ckad-simulation2"
-CURRENT_EXAM_ID="${CURRENT_EXAM_ID:-$DEFAULT_EXAM_ID}"
+# Current exam (set by load_exam or interactive selection)
+CURRENT_EXAM_ID="${CURRENT_EXAM_ID:-}"
 
 # Legacy paths (for backward compatibility)
 MANIFESTS_DIR="$PROJECT_DIR/manifests/setup"
@@ -32,7 +31,7 @@ EXAM_DIR="$PROJECT_DIR/exam/course"
 # Load exam configuration
 # Usage: load_exam <exam_id>
 load_exam() {
-	local exam_id=${1:-$DEFAULT_EXAM_ID}
+	local exam_id=$1
 	local exam_conf="$EXAMS_DIR/$exam_id/exam.conf"
 
 	if [ ! -f "$exam_conf" ]; then
@@ -82,6 +81,52 @@ list_available_exams() {
 exam_exists() {
 	local exam_id=$1
 	[ -d "$EXAMS_DIR/$exam_id" ] && [ -f "$EXAMS_DIR/$exam_id/exam.conf" ]
+}
+
+# Interactive exam selection menu
+# Sets the global SELECTED_EXAM variable
+select_exam_interactive() {
+	local exams
+	IFS=' ' read -r -a exams <<<"$(list_available_exams)"
+	local num_exams=${#exams[@]}
+
+	if [ "$num_exams" -eq 0 ]; then
+		print_error "No exams found in $EXAMS_DIR"
+		exit 1
+	fi
+
+	echo ""
+	echo -e "${BLUE}╔═══════════════════════════════════════════════════════════════════╗${NC}"
+	echo -e "${BLUE}║${NC}                     SELECT AN EXAM                                ${BLUE}║${NC}"
+	echo -e "${BLUE}╠═══════════════════════════════════════════════════════════════════╣${NC}"
+	echo -e "${BLUE}║${NC}"
+
+	local i=1
+	for exam_id in "${exams[@]}"; do
+		source "$EXAMS_DIR/$exam_id/exam.conf"
+		printf "${BLUE}║${NC}  ${CYAN}%d)${NC} %-20s - %s\n" "$i" "$exam_id" "$EXAM_NAME"
+		printf "${BLUE}║${NC}     Duration: %d min | Questions: %d | Points: %d\n" \
+			"$EXAM_DURATION" "$TOTAL_QUESTIONS" "$TOTAL_POINTS"
+		echo -e "${BLUE}║${NC}"
+		((i++))
+	done
+
+	echo -e "${BLUE}╚═══════════════════════════════════════════════════════════════════╝${NC}"
+	echo ""
+
+	local selection
+	while true; do
+		read -r -p "Select an exam: " selection
+		if [[ "$selection" =~ ^[0-9]+$ ]] && [ "$selection" -ge 1 ] && [ "$selection" -le "$num_exams" ]; then
+			SELECTED_EXAM="${exams[$((selection - 1))]}"
+			break
+		else
+			echo -e "${RED}Invalid selection. Please enter a valid exam number.${NC}"
+		fi
+	done
+
+	echo ""
+	echo -e "${GREEN}Selected:${NC} $SELECTED_EXAM"
 }
 
 # ============================================================================

--- a/tests/test-common.sh
+++ b/tests/test-common.sh
@@ -225,12 +225,11 @@ assert_function_exists "open_browser_tab" "open_browser_tab function should exis
 assert_function_exists "open_docs_tabs" "open_docs_tabs function should exist"
 
 # ----------------------------------------------------------------------------
-# Test: Default exam configuration
+# Test: No default exam ID (interactive selection required)
 # ----------------------------------------------------------------------------
-test_case "Default exam configuration is set"
+test_case "DEFAULT_EXAM_ID is no longer defined"
 
-assert_not_empty "$DEFAULT_EXAM_ID" "DEFAULT_EXAM_ID should be set"
-assert_equals "ckad-simulation2" "$DEFAULT_EXAM_ID" "DEFAULT_EXAM_ID should be ckad-simulation2"
+assert_equals "" "${DEFAULT_EXAM_ID:-}" "DEFAULT_EXAM_ID should not be set"
 
 # ----------------------------------------------------------------------------
 # Test: Legacy path variables


### PR DESCRIPTION
## Summary
- Remove `DEFAULT_EXAM_ID` global variable that caused silent fallback to `ckad-simulation2`
- Move `select_exam_interactive()` to `common.sh` for shared use across all scripts
- Each script now has explicit, safe behavior when no `-e` flag is provided:
  - `ckad-setup.sh`: interactive exam selection menu
  - `ckad-score.sh`: detects active exam or fails with clear error message
  - `ckad-cleanup.sh`: detects active exam or falls back to interactive menu

## Test plan
- [x] All unit tests pass (536 tests, 0 failures)
- [x] shellcheck clean
- [x] Pre-commit hooks pass
- [x] `./scripts/ckad-setup.sh` without `-e` shows interactive menu
- [x] `./scripts/ckad-score.sh` without `-e` and no active exam shows error
- [x] `./scripts/ckad-cleanup.sh` without `-e` and no active exam shows interactive menu
- [x] `./scripts/ckad-exam.sh` behavior unchanged
- [x] All scripts work normally with `-e ckad-simulation1`
- [x] Web interface unaffected (server.py always passes `-e` explicitly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)