### PR TITLE
fix(simulation6): pin all container images to reliable tags

### DIFF
--- a/exams/ckad-simulation6/manifests/setup/q07-rollback-deploy.yaml
+++ b/exams/ckad-simulation6/manifests/setup/q07-rollback-deploy.yaml
@@ -17,6 +17,6 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: nginx:1.19
+        image: nginx:1.19.10
         ports:
         - containerPort: 80

--- a/exams/ckad-simulation6/questions.md
+++ b/exams/ckad-simulation6/questions.md
@@ -26,11 +26,11 @@
 
 ### Task
 
-Create a namespace called `mynamespace` and a Pod with image `nginx` called `nginx` in this namespace.
+Create a namespace called `mynamespace` and a Pod with image `nginx:1.25` called `nginx` in this namespace.
 
 The Pod should:
 
-- Use the `nginx` image
+- Use the `nginx:1.25` image
 - Have `restartPolicy: Never`
 
 **Hint**: Use `kubectl create namespace` and `kubectl run` commands.
@@ -49,7 +49,7 @@ The Pod should:
 
 Create a Pod named `envpod` in namespace `summit` with the following specifications:
 
-- Image: `busybox`
+- Image: `busybox:1.36`
 - Command: `env` (to print environment variables)
 - Environment variable: `VAR1=value1`
 - `restartPolicy: Never`
@@ -92,7 +92,7 @@ Create a ResourceQuota named `cliff-quota` in namespace `cliff` with the followi
 
 In namespace `ridge`:
 
-1. Create 3 Pods with names `nginx1`, `nginx2`, `nginx3`. All of them should have the label `app=v1`
+1. Create 3 Pods with names `nginx1`, `nginx2`, `nginx3` using image `nginx:1.25`. All of them should have the label `app=v1`
 2. Change the label of Pod `nginx2` to `app=v2`
 3. Add a new label `tier=web` to all Pods having label `app=v1`
 
@@ -174,7 +174,7 @@ A Deployment `rollback-deploy` exists in namespace `cave` with a wrong image `ng
 
 Create a Job named `echo-job` in namespace `stone` that:
 
-- Uses image `busybox`
+- Uses image `busybox:1.36`
 - Runs the command: `echo hello; sleep 5; echo world`
 - Should complete `5` times sequentially (one after the other)
 
@@ -194,7 +194,7 @@ Create a Job named `echo-job` in namespace `stone` that:
 
 Create a CronJob named `date-job` in namespace `mist` that:
 
-- Uses image `busybox`
+- Uses image `busybox:1.36`
 - Runs every minute (`*/1 * * * *`)
 - Executes the command: `date; echo Hello from Kubernetes`
 
@@ -217,13 +217,13 @@ Create a Pod named `multi-container` in namespace `alpine` with two containers:
 **Container 1:**
 
 - Name: `container1`
-- Image: `busybox`
+- Image: `busybox:1.36`
 - Command: `echo hello; sleep 3600`
 
 **Container 2:**
 
 - Name: `container2`
-- Image: `busybox`
+- Image: `busybox:1.36`
 - Command: `echo hello; sleep 3600`
 
 **Hint**: Generate YAML with `--dry-run=client -o yaml` and add the second container.
@@ -245,14 +245,14 @@ Create a Pod named `init-pod` in namespace `crest` with:
 **Main container:**
 
 - Name: `nginx`
-- Image: `nginx`
+- Image: `nginx:1.25`
 - Port: `80`
 - Volume mount: `/usr/share/nginx/html`
 
 **Init container:**
 
 - Name: `init`
-- Image: `busybox`
+- Image: `busybox:1.36`
 - Command: `echo "Initialized" > /work-dir/index.html`
 - Volume mount: `/work-dir`
 
@@ -292,7 +292,7 @@ Create a ConfigMap named `app-config` in namespace `peak` with the following key
 ### Task
 
 1. Create a ConfigMap named `options` in namespace `summit` with value `var5=val5`
-2. Create a Pod named `config-pod` with image `nginx` that loads the value from key `var5` into an environment variable called `OPTION`
+2. Create a Pod named `config-pod` with image `nginx:1.25` that loads the value from key `var5` into an environment variable called `OPTION`
 
 **Hint**: Use `valueFrom.configMapKeyRef` in the Pod spec.
 
@@ -309,7 +309,7 @@ Create a ConfigMap named `app-config` in namespace `peak` with the following key
 ### Task
 
 1. Create a ConfigMap named `cmvolume` in namespace `cliff` with values `var8=val8` and `var9=val9`
-2. Create a Pod named `vol-pod` with image `nginx` that mounts this ConfigMap as a volume at `/etc/lala`
+2. Create a Pod named `vol-pod` with image `nginx:1.25` that mounts this ConfigMap as a volume at `/etc/lala`
 
 **Hint**: Use `volumes` and `volumeMounts` in the Pod spec.
 
@@ -326,7 +326,7 @@ Create a ConfigMap named `app-config` in namespace `peak` with the following key
 ### Task
 
 1. Create a Secret named `mysecret` in namespace `ridge` with value `password=mypass`
-2. Create a Pod named `secret-pod` with image `nginx` that mounts the Secret as a volume at `/etc/foo`
+2. Create a Pod named `secret-pod` with image `nginx:1.25` that mounts the Secret as a volume at `/etc/foo`
 
 **Hint**: Use `kubectl create secret generic` and mount it as a volume.
 
@@ -344,7 +344,7 @@ Create a ConfigMap named `app-config` in namespace `peak` with the following key
 
 Create a Pod named `secure-pod` in namespace `valley` with:
 
-- Image: `busybox`
+- Image: `busybox:1.36`
 - Command: `sleep 3600`
 - Run as user ID: `101`
 - `restartPolicy: Never`
@@ -365,7 +365,7 @@ Create a Pod named `secure-pod` in namespace `valley` with:
 
 Create a Pod named `resource-pod` in namespace `cave` with:
 
-- Image: `nginx`
+- Image: `nginx:1.25`
 - Resource requests: `cpu=100m`, `memory=256Mi`
 - Resource limits: `cpu=200m`, `memory=512Mi`
 
@@ -385,7 +385,7 @@ Create a Pod named `resource-pod` in namespace `cave` with:
 
 Create a Pod named `liveness-pod` in namespace `stone` with:
 
-- Image: `nginx`
+- Image: `nginx:1.25`
 - Liveness probe that executes the command `ls`
 - Initial delay: `5` seconds
 - Period: `5` seconds
@@ -404,7 +404,7 @@ Create a Pod named `liveness-pod` in namespace `stone` with:
 
 ### Task
 
-1. Create a Deployment named `web` in namespace `mist` with image `nginx` and 2 replicas
+1. Create a Deployment named `web` in namespace `mist` with image `nginx:1.25` and 2 replicas
 2. Expose it via a ClusterIP Service named `web` on port `80`
 3. Create a NetworkPolicy named `web-policy` that only allows ingress traffic to this Deployment from Pods with label `access=granted`
 

--- a/exams/ckad-simulation6/questions.md
+++ b/exams/ckad-simulation6/questions.md
@@ -433,6 +433,6 @@ Create a Pod named `liveness-pod` in namespace `stone` with:
    - Access mode: `ReadWriteOnce`
    - Storage class: `normal`
 
-3. Create a Pod named `pv-pod` in namespace `alpine` that uses the PVC and mounts it at `/etc/foo`
+3. Create a Pod named `pv-pod` in namespace `alpine` with image `busybox:1.36` that uses the PVC and mounts it at `/etc/foo`
 
 **Hint**: PersistentVolumes are cluster-scoped (no namespace).

--- a/exams/ckad-simulation6/solutions.md
+++ b/exams/ckad-simulation6/solutions.md
@@ -15,7 +15,7 @@
 kubectl create namespace mynamespace
 
 # Create pod
-kubectl run nginx --image=nginx --restart=Never -n mynamespace
+kubectl run nginx --image=nginx:1.25 --restart=Never -n mynamespace
 ```
 
 Or using YAML:
@@ -29,7 +29,7 @@ metadata:
 spec:
   containers:
   - name: nginx
-    image: nginx
+    image: nginx:1.25
   restartPolicy: Never
 ```
 
@@ -40,7 +40,7 @@ spec:
 ### Solution
 
 ```bash
-kubectl run envpod --image=busybox --restart=Never -n summit --env=VAR1=value1 -- env
+kubectl run envpod --image=busybox:1.36 --restart=Never -n summit --env=VAR1=value1 -- env
 ```
 
 Or using YAML:
@@ -54,7 +54,7 @@ metadata:
 spec:
   containers:
   - name: envpod
-    image: busybox
+    image: busybox:1.36
     command: ["env"]
     env:
     - name: VAR1
@@ -95,9 +95,9 @@ spec:
 
 ```bash
 # Create 3 pods with label app=v1
-kubectl run nginx1 --image=nginx --restart=Never -n ridge --labels=app=v1
-kubectl run nginx2 --image=nginx --restart=Never -n ridge --labels=app=v1
-kubectl run nginx3 --image=nginx --restart=Never -n ridge --labels=app=v1
+kubectl run nginx1 --image=nginx:1.25 --restart=Never -n ridge --labels=app=v1
+kubectl run nginx2 --image=nginx:1.25 --restart=Never -n ridge --labels=app=v1
+kubectl run nginx3 --image=nginx:1.25 --restart=Never -n ridge --labels=app=v1
 
 # Change nginx2 label to app=v2
 kubectl label po nginx2 -n ridge app=v2 --overwrite
@@ -182,7 +182,7 @@ kubectl get pods -n cave -l app=rollback-deploy
 ### Solution
 
 ```bash
-kubectl create job echo-job --image=busybox -n stone --dry-run=client -o yaml -- /bin/sh -c 'echo hello; sleep 5; echo world' > job.yaml
+kubectl create job echo-job --image=busybox:1.36 -n stone --dry-run=client -o yaml -- /bin/sh -c 'echo hello; sleep 5; echo world' > job.yaml
 ```
 
 Edit job.yaml to add `completions: 5`:
@@ -199,7 +199,7 @@ spec:
     spec:
       containers:
       - name: echo-job
-        image: busybox
+        image: busybox:1.36
         command: ["/bin/sh", "-c", "echo hello; sleep 5; echo world"]
       restartPolicy: Never
 ```
@@ -215,7 +215,7 @@ kubectl apply -f job.yaml
 ### Solution
 
 ```bash
-kubectl create cronjob date-job --image=busybox --schedule="*/1 * * * *" -n mist -- /bin/sh -c 'date; echo Hello from Kubernetes'
+kubectl create cronjob date-job --image=busybox:1.36 --schedule="*/1 * * * *" -n mist -- /bin/sh -c 'date; echo Hello from Kubernetes'
 ```
 
 ---
@@ -233,10 +233,10 @@ metadata:
 spec:
   containers:
   - name: container1
-    image: busybox
+    image: busybox:1.36
     command: ["/bin/sh", "-c", "echo hello; sleep 3600"]
   - name: container2
-    image: busybox
+    image: busybox:1.36
     command: ["/bin/sh", "-c", "echo hello; sleep 3600"]
 ```
 
@@ -255,14 +255,14 @@ metadata:
 spec:
   initContainers:
   - name: init
-    image: busybox
+    image: busybox:1.36
     command: ["/bin/sh", "-c", "echo 'Initialized' > /work-dir/index.html"]
     volumeMounts:
     - name: workdir
       mountPath: /work-dir
   containers:
   - name: nginx
-    image: nginx
+    image: nginx:1.25
     ports:
     - containerPort: 80
     volumeMounts:
@@ -304,7 +304,7 @@ metadata:
 spec:
   containers:
   - name: nginx
-    image: nginx
+    image: nginx:1.25
     env:
     - name: OPTION
       valueFrom:
@@ -334,7 +334,7 @@ metadata:
 spec:
   containers:
   - name: nginx
-    image: nginx
+    image: nginx:1.25
     volumeMounts:
     - name: config-volume
       mountPath: /etc/lala
@@ -365,7 +365,7 @@ metadata:
 spec:
   containers:
   - name: nginx
-    image: nginx
+    image: nginx:1.25
     volumeMounts:
     - name: secret-volume
       mountPath: /etc/foo
@@ -393,7 +393,7 @@ spec:
   restartPolicy: Never
   containers:
   - name: secure-pod
-    image: busybox
+    image: busybox:1.36
     command: ["sleep", "3600"]
 ```
 
@@ -414,7 +414,7 @@ metadata:
 spec:
   containers:
   - name: nginx
-    image: nginx
+    image: nginx:1.25
     resources:
       requests:
         cpu: "100m"
@@ -439,7 +439,7 @@ metadata:
 spec:
   containers:
   - name: nginx
-    image: nginx
+    image: nginx:1.25
     livenessProbe:
       exec:
         command:
@@ -456,7 +456,7 @@ spec:
 
 ```bash
 # Create Deployment
-kubectl create deployment web --image=nginx --replicas=2 -n mist
+kubectl create deployment web --image=nginx:1.25 --replicas=2 -n mist
 
 # Expose as Service
 kubectl expose deployment web --port=80 -n mist
@@ -527,7 +527,7 @@ metadata:
 spec:
   containers:
   - name: busybox
-    image: busybox
+    image: busybox:1.36
     command: ["sleep", "3600"]
     volumeMounts:
     - name: pv-storage


### PR DESCRIPTION
## Summary

- Pin all untagged `nginx` → `nginx:1.25` and `busybox` → `busybox:1.36` across questions.md, solutions.md
- Pin Q7 manifest working image from `nginx:1.19` (floating) → `nginx:1.19.10` (fixed)
- Add missing image specification in Q20 question text
- Intentionally broken `nginx:1.91` (rollback exercise) left unchanged
- Scoring functions unchanged (wildcard patterns already match tagged images)

## Test plan

- [x] Verified no untagged `nginx`/`busybox` remain in questions or solutions
- [x] Run simulation 6 exam and verify scoring works correctly
- [x] Verify Q7 rollback exercise still works (broken → working image flow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)