### PR TITLE
fix(scorecard): use commit SHA instead of annotated tag SHA

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -25,7 +25,7 @@ jobs:
           persist-credentials: false
 
       - name: Run OpenSSF Scorecard
-        uses: ossf/scorecard-action@ff5dd8929f96a8a4dc67d13f32b8c75057829621 # v2.4.0
+        uses: ossf/scorecard-action@62b2cac7ed8198b15735ed49ab1e5cf35480ba46 # v2.4.0
         with:
           results_file: results.sarif
           results_format: sarif


### PR DESCRIPTION
## Summary

- Fix "imposter commit" error in Scorecard workflow
- The `ossf/scorecard-action` v2.4.0 tag is an annotated tag — the tag object SHA (`ff5dd89...`) was rejected by the Scorecard webapp
- Replace with the actual commit SHA (`62b2cac...`) that the tag points to

## Test plan

- [ ] Scorecard workflow passes on merge to main
- [ ] Badge renders correctly on README

🤖 Generated with [Claude Code](https://claude.com/claude-code)