### PR TITLE
fix(scorecard): dereference codeql-action annotated tag SHA

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -32,6 +32,6 @@ jobs:
           publish_results: true
 
       - name: Upload SARIF results
-        uses: github/codeql-action/upload-sarif@9792ccaef0455e446c567163589397e8c3ac2e0d # v3
+        uses: github/codeql-action/upload-sarif@820e3160e279568db735cee8ed8f8e77a6da7818 # v3
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## Summary

- Fix second "imposter commit" error: `codeql-action` v3 tag is also an annotated tag
- Replace tag object SHA (`9792ccae...`) with actual commit SHA (`820e3160...`)
- Both `ossf/scorecard-action` and `github/codeql-action` now use dereferenced commit SHAs

## Test plan

- [ ] Scorecard workflow passes on merge to main
- [ ] Badge renders correctly on README

🤖 Generated with [Claude Code](https://claude.com/claude-code)