### PR TITLE
fix(simulation7): pin all container images to reliable tags

### DIFF
--- a/exams/ckad-simulation7/questions.md
+++ b/exams/ckad-simulation7/questions.md
@@ -26,7 +26,7 @@
 
 ### Task
 
-Create a Pod with image `nginx` called `nginx` in namespace `grove` and expose its port `80`.
+Create a Pod with image `nginx:1.25` called `nginx` in namespace `grove` and expose its port `80`.
 
 The `--expose` flag should create both the Pod and a ClusterIP Service.
 
@@ -44,9 +44,9 @@ The `--expose` flag should create both the Pod and a ClusterIP Service.
 
 ### Task
 
-1. Create a Pod named `web` with image `nginx` in namespace `thicket`
+1. Create a Pod named `web` with image `nginx:1.25` in namespace `thicket`
 2. Get the Pod's IP address and save it to `./exam/course/2/pod-ip.txt`
-3. Verify connectivity by running a temporary busybox Pod that wget's the IP
+3. Verify connectivity by running a temporary `busybox:1.36` Pod that wget's the IP
 
 **Hint**: Use `kubectl get pod -o wide` or `-o jsonpath` to get the IP.
 
@@ -62,7 +62,7 @@ The `--expose` flag should create both the Pod and a ClusterIP Service.
 
 ### Task
 
-Create a Pod named `logger` in namespace `glade` with image `busybox` that runs the command:
+Create a Pod named `logger` in namespace `glade` with image `busybox:1.36` that runs the command:
 
 ```
 i=0; while true; do echo "$i: $(date)"; i=$((i+1)); sleep 1; done
@@ -84,7 +84,7 @@ After the Pod is running, save the first 10 lines of logs to `./exam/course/3/lo
 
 ### Task
 
-Create a Pod named `debug-pod` in namespace `meadow` with image `busybox` that runs the command `ls /notexist`.
+Create a Pod named `debug-pod` in namespace `meadow` with image `busybox:1.36` that runs the command `ls /notexist`.
 
 1. Get the Pod's logs and save to `./exam/course/4/error.txt`
 2. The file should contain the error message
@@ -103,7 +103,7 @@ Create a Pod named `debug-pod` in namespace `meadow` with image `busybox` that r
 
 ### Task
 
-Create a Pod named `gpu-pod` in namespace `fern` with image `nginx` that will be scheduled on a Node with the label `accelerator=nvidia`.
+Create a Pod named `gpu-pod` in namespace `fern` with image `nginx:1.25` that will be scheduled on a Node with the label `accelerator=nvidia`.
 
 Use `nodeSelector` to achieve this.
 
@@ -123,7 +123,7 @@ Use `nodeSelector` to achieve this.
 
 ### Task
 
-Create a Pod named `tolerate-pod` in namespace `moss` with image `nginx` that tolerates the taint `tier=frontend:NoSchedule`.
+Create a Pod named `tolerate-pod` in namespace `moss` with image `nginx:1.25` that tolerates the taint `tier=frontend:NoSchedule`.
 
 The Pod should have:
 
@@ -231,7 +231,7 @@ A Deployment `pause-deploy` exists in namespace `bark` with image `nginx:1.18.0`
 
 Create a Job named `parallel-job` in namespace `canopy` that:
 
-- Uses image `busybox`
+- Uses image `busybox:1.36`
 - Runs the command: `echo hello; sleep 5; echo world`
 - Runs `5` Pods in parallel (parallelism)
 
@@ -251,7 +251,7 @@ Create a Job named `parallel-job` in namespace `canopy` that:
 
 Create a Job named `deadline-job` in namespace `hollow` that:
 
-- Uses image `busybox`
+- Uses image `busybox:1.36`
 - Runs the command: `while true; do echo hello; sleep 10; done`
 - Should be automatically terminated if it takes more than `30` seconds
 
@@ -271,7 +271,7 @@ Create a Job named `deadline-job` in namespace `hollow` that:
 
 Create a CronJob named `deadline-cron` in namespace `grove` that:
 
-- Uses image `busybox`
+- Uses image `busybox:1.36`
 - Runs every minute (`* * * * *`)
 - Executes: `date; echo Hello from CronJob`
 - Should be terminated if it takes more than `17` seconds to start after its scheduled time
@@ -290,7 +290,7 @@ Create a CronJob named `deadline-cron` in namespace `grove` that:
 
 ### Task
 
-1. Create a CronJob named `source-cron` in namespace `thicket` with image `busybox`, schedule `*/5 * * * *`, command `echo "source job"`
+1. Create a CronJob named `source-cron` in namespace `thicket` with image `busybox:1.36`, schedule `*/5 * * * *`, command `echo "source job"`
 2. Create a Job named `manual-job` from this CronJob
 
 **Hint**: Use `kubectl create job --from=cronjob/NAME`.
@@ -331,7 +331,7 @@ Create a CronJob named `deadline-cron` in namespace `grove` that:
 ### Task
 
 1. Create a ConfigMap named `env-config` in namespace `meadow` with values `var6=val6` and `var7=val7`
-2. Create a Pod named `env-pod` with image `nginx` that loads ALL keys from this ConfigMap as environment variables (use `envFrom`)
+2. Create a Pod named `env-pod` with image `nginx:1.25` that loads ALL keys from this ConfigMap as environment variables (use `envFrom`)
 
 **Hint**: Use `envFrom.configMapRef` in the Pod spec.
 
@@ -365,7 +365,7 @@ Create a CronJob named `deadline-cron` in namespace `grove` that:
 ### Task
 
 1. Create a Secret named `api-secret` in namespace `moss` with key `API_KEY=LmLHbYhsgWZwNifiqaRorH8T`
-2. Create a Pod named `api-pod` with image `nginx` that loads this key into an environment variable called `API_KEY`
+2. Create a Pod named `api-pod` with image `nginx:1.25` that loads this key into an environment variable called `API_KEY`
 
 **Hint**: Use `env.valueFrom.secretKeyRef` in the Pod spec.
 
@@ -382,7 +382,7 @@ Create a CronJob named `deadline-cron` in namespace `grove` that:
 ### Task
 
 1. Create a ServiceAccount named `app-sa` in namespace `root`
-2. Create a Pod named `sa-pod` with image `nginx` that uses this ServiceAccount
+2. Create a Pod named `sa-pod` with image `nginx:1.25` that uses this ServiceAccount
 
 **Hint**: Use `spec.serviceAccountName` in the Pod spec.
 
@@ -398,7 +398,7 @@ Create a CronJob named `deadline-cron` in namespace `grove` that:
 
 ### Task
 
-1. Create a Pod named `copy-pod` in namespace `bark` with image `busybox` and command `sleep 3600`
+1. Create a Pod named `copy-pod` in namespace `bark` with image `busybox:1.36` and command `sleep 3600`
 2. Copy `/etc/passwd` from the Pod to `./exam/course/20/passwd`
 
 **Hint**: Use `kubectl cp` command.

--- a/exams/ckad-simulation7/solutions.md
+++ b/exams/ckad-simulation7/solutions.md
@@ -11,7 +11,7 @@
 ### Solution
 
 ```bash
-kubectl run nginx --image=nginx --restart=Never --port=80 --expose -n grove
+kubectl run nginx --image=nginx:1.25 --restart=Never --port=80 --expose -n grove
 ```
 
 This creates both a Pod and a ClusterIP Service.
@@ -32,7 +32,7 @@ kubectl get ep nginx -n grove
 
 ```bash
 # Create the Pod
-kubectl run web --image=nginx --restart=Never -n thicket
+kubectl run web --image=nginx:1.25 --restart=Never -n thicket
 
 # Get the Pod IP and save to file
 mkdir -p ./exam/course/2
@@ -40,7 +40,7 @@ kubectl get pod web -n thicket -o jsonpath='{.status.podIP}' > ./exam/course/2/p
 
 # Test connectivity
 IP=$(cat ./exam/course/2/pod-ip.txt)
-kubectl run busybox --rm -it --restart=Never --image=busybox -n thicket -- wget -O- $IP:80
+kubectl run busybox --rm -it --restart=Never --image=busybox:1.36 -n thicket -- wget -O- $IP:80
 ```
 
 ---
@@ -51,7 +51,7 @@ kubectl run busybox --rm -it --restart=Never --image=busybox -n thicket -- wget 
 
 ```bash
 # Create the Pod
-kubectl run logger --image=busybox --restart=Never -n glade -- /bin/sh -c 'i=0; while true; do echo "$i: $(date)"; i=$((i+1)); sleep 1; done'
+kubectl run logger --image=busybox:1.36 --restart=Never -n glade -- /bin/sh -c 'i=0; while true; do echo "$i: $(date)"; i=$((i+1)); sleep 1; done'
 
 # Wait for Pod to start
 kubectl wait --for=condition=Ready pod/logger -n glade --timeout=30s
@@ -69,7 +69,7 @@ kubectl logs logger -n glade | head -10 > ./exam/course/3/logs.txt
 
 ```bash
 # Create the Pod with error command
-kubectl run debug-pod --image=busybox --restart=Never -n meadow -- ls /notexist
+kubectl run debug-pod --image=busybox:1.36 --restart=Never -n meadow -- ls /notexist
 
 # Wait a moment for the Pod to complete
 sleep 2
@@ -96,7 +96,7 @@ spec:
     accelerator: nvidia
   containers:
   - name: nginx
-    image: nginx
+    image: nginx:1.25
 ```
 
 ```bash
@@ -118,7 +118,7 @@ metadata:
 spec:
   containers:
   - name: nginx
-    image: nginx
+    image: nginx:1.25
   tolerations:
   - key: "tier"
     operator: "Equal"
@@ -239,7 +239,7 @@ spec:
     spec:
       containers:
       - name: busybox
-        image: busybox
+        image: busybox:1.36
         command: ["/bin/sh", "-c", "echo hello; sleep 5; echo world"]
       restartPolicy: Never
 ```
@@ -266,7 +266,7 @@ spec:
     spec:
       containers:
       - name: busybox
-        image: busybox
+        image: busybox:1.36
         command: ["/bin/sh", "-c", "while true; do echo hello; sleep 10; done"]
       restartPolicy: Never
 ```
@@ -296,7 +296,7 @@ spec:
         spec:
           containers:
           - name: busybox
-            image: busybox
+            image: busybox:1.36
             command: ["/bin/sh", "-c", "date; echo Hello from CronJob"]
           restartPolicy: Never
 ```
@@ -313,7 +313,7 @@ kubectl apply -f deadline-cron.yaml
 
 ```bash
 # Create the CronJob
-kubectl create cronjob source-cron --image=busybox --schedule="*/5 * * * *" -n thicket -- echo "source job"
+kubectl create cronjob source-cron --image=busybox:1.36 --schedule="*/5 * * * *" -n thicket -- echo "source job"
 
 # Create a Job from the CronJob
 kubectl create job manual-job --from=cronjob/source-cron -n thicket
@@ -361,7 +361,7 @@ metadata:
 spec:
   containers:
   - name: nginx
-    image: nginx
+    image: nginx:1.25
     envFrom:
     - configMapRef:
         name: env-config
@@ -414,7 +414,7 @@ metadata:
 spec:
   containers:
   - name: nginx
-    image: nginx
+    image: nginx:1.25
     env:
     - name: API_KEY
       valueFrom:
@@ -450,7 +450,7 @@ spec:
   serviceAccountName: app-sa
   containers:
   - name: nginx
-    image: nginx
+    image: nginx:1.25
 ```
 
 ```bash
@@ -466,7 +466,7 @@ kubectl get pod sa-pod -n root -o jsonpath='{.spec.serviceAccountName}'
 
 ```bash
 # Create Pod
-kubectl run copy-pod --image=busybox --restart=Never -n bark -- sleep 3600
+kubectl run copy-pod --image=busybox:1.36 --restart=Never -n bark -- sleep 3600
 
 # Wait for Pod to be ready
 kubectl wait --for=condition=Ready pod/copy-pod -n bark --timeout=30s


### PR DESCRIPTION
## Summary
- Pin all untagged container images in simulation 7 (Dojo Tanuki 🦝) to explicit versions
- `nginx` → `nginx:1.25`, `busybox` → `busybox:1.36` across questions.md and solutions.md
- Intentional versioned images for rollout exercises (Q7 `nginx:1.18.0`, Q10 `nginx:1.18.0` → `nginx:1.19.0`) are preserved unchanged

## Test plan
- [x] Verify questions render correctly in web UI
- [ ] Verify solutions match question image references
- [ ] Confirm scoring functions still work (use wildcard matching, no changes needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)