### PR TITLE
docs(readme): add GitHub Actions workflow to project structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -470,6 +470,9 @@ Questions reference paths like `/opt/course/N/` (as in the real CKAD exam). Loca
 
 ```
 ckad-dojo/
+├── .github/
+│   └── workflows/
+│       └── scorecard.yml     # OpenSSF Scorecard security analysis
 ├── ckad_dojo.py              # Unified Python CLI
 ├── pyproject.toml            # Python project config (uv)
 ├── scripts/


### PR DESCRIPTION
## Summary
- Add `.github/workflows/scorecard.yml` entry to the project structure section in README.md
- Improves visibility of the OpenSSF Scorecard CI integration

## Test plan
- [ ] Verify README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)