### PR TITLE
fix(simulation8,simulation9): pin all container images to reliable tags

### DIFF
--- a/exams/ckad-simulation8/manifests/setup/q02-app-svc.yaml
+++ b/exams/ckad-simulation8/manifests/setup/q02-app-svc.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   containers:
   - name: nginx
-    image: nginx
+    image: nginx:1.25
     ports:
     - containerPort: 80
 ---

--- a/exams/ckad-simulation8/manifests/setup/q18-web-svc.yaml
+++ b/exams/ckad-simulation8/manifests/setup/q18-web-svc.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   containers:
   - name: nginx
-    image: nginx
+    image: nginx:1.25
     ports:
     - containerPort: 80
 ---

--- a/exams/ckad-simulation8/questions.md
+++ b/exams/ckad-simulation8/questions.md
@@ -26,7 +26,7 @@
 
 ### Task
 
-1. Create a Pod named `web` with image `nginx` in namespace `harvest`, exposing port `80`
+1. Create a Pod named `web` with image `nginx:1.25` in namespace `harvest`, exposing port `80`
 2. Create a ClusterIP Service named `web` that exposes the Pod on port `80`
 3. Verify the Service has endpoints
 
@@ -62,7 +62,7 @@ Convert this Service to a `NodePort` type.
 
 ### Task
 
-1. Create a Deployment named `backend` in namespace `rice` with image `nginx` and 3 replicas, exposing port `8080`
+1. Create a Deployment named `backend` in namespace `rice` with image `nginx:1.25` and 3 replicas, exposing port `8080`
 2. Create a Service named `backend` that exposes the Deployment on port `6262` targeting port `8080`
 
 **Hint**: Use `kubectl create deployment` and `kubectl expose`.
@@ -79,7 +79,7 @@ Convert this Service to a `NodePort` type.
 
 ### Task
 
-Create a Pod named `ready-pod` in namespace `field` with image `nginx` that includes:
+Create a Pod named `ready-pod` in namespace `field` with image `nginx:1.25` that includes:
 
 - Container port: `80`
 - HTTP readiness probe on path `/` on port `80`
@@ -98,7 +98,7 @@ Create a Pod named `ready-pod` in namespace `field` with image `nginx` that incl
 
 ### Task
 
-Create a Pod named `live-pod` in namespace `shrine` with image `nginx` that includes:
+Create a Pod named `live-pod` in namespace `shrine` with image `nginx:1.25` that includes:
 
 - Liveness probe that executes the command `ls`
 - Initial delay: `5` seconds
@@ -158,7 +158,7 @@ Create a ResourceQuota named `compute-quota` in namespace `fortune` with:
 
 In namespace `fortune` (which has a ResourceQuota), create a Pod named `quota-pod` with:
 
-- Image: `nginx`
+- Image: `nginx:1.25`
 - Resource requests: `cpu=0.5`, `memory=512Mi`
 - Resource limits: `cpu=1`, `memory=1Gi`
 
@@ -176,7 +176,7 @@ In namespace `fortune` (which has a ResourceQuota), create a Pod named `quota-po
 
 ### Task
 
-Create a Pod named `cap-pod` in namespace `golden` with image `nginx` that adds the capabilities:
+Create a Pod named `cap-pod` in namespace `golden` with image `nginx:1.25` that adds the capabilities:
 
 - `NET_ADMIN`
 - `SYS_TIME`
@@ -200,14 +200,14 @@ Create a Pod named `shared-pod` in namespace `bounty` with two containers:
 **Container 1:**
 
 - Name: `writer`
-- Image: `busybox`
+- Image: `busybox:1.36`
 - Command: `sleep 3600`
 - Mount emptyDir volume at `/data`
 
 **Container 2:**
 
 - Name: `reader`
-- Image: `busybox`
+- Image: `busybox:1.36`
 - Command: `sleep 3600`
 - Mount same emptyDir volume at `/data`
 
@@ -227,7 +227,7 @@ Both containers should share the same `emptyDir` volume named `shared-data`.
 
 ### Task
 
-1. Create a Pod named `annotated-pod` with image `nginx` in namespace `prosperity`
+1. Create a Pod named `annotated-pod` with image `nginx:1.25` in namespace `prosperity`
 2. Add the annotation `owner=marketing` to the Pod
 
 **Hint**: Use `kubectl annotate` or add `metadata.annotations` in YAML.
@@ -244,7 +244,7 @@ Both containers should share the same `emptyDir` volume named `shared-data`.
 
 ### Task
 
-1. Create 3 Pods in namespace `harvest`: `pod1`, `pod2`, `pod3` all with image `nginx`
+1. Create 3 Pods in namespace `harvest`: `pod1`, `pod2`, `pod3` all with image `nginx:1.25`
 2. Label `pod1` and `pod2` with `env=prod`
 3. Label `pod3` with `env=dev`
 4. List all Pods with label `env=prod` and save the output to `./exam/course/12/pods.txt`
@@ -341,7 +341,7 @@ This achieves a 75%-25% traffic split.
 Create a Pod named `data-pod` in namespace `rice` with:
 
 - Two containers: `producer` and `consumer`
-- Both use image `busybox` with command `sleep 3600`
+- Both use image `busybox:1.36` with command `sleep 3600`
 - Both mount an emptyDir volume at `/shared`
 - Volume name: `data-volume`
 
@@ -361,7 +361,7 @@ Create a Pod named `data-pod` in namespace `rice` with:
 
 A Service named `web-svc` exists in namespace `field`.
 
-From a temporary busybox Pod, resolve the DNS name of this Service and save the IP to `./exam/course/18/dns.txt`.
+From a temporary `busybox:1.36` Pod, resolve the DNS name of this Service and save the IP to `./exam/course/18/dns.txt`.
 
 **Hint**: Use `nslookup web-svc.field.svc.cluster.local`.
 

--- a/exams/ckad-simulation8/solutions.md
+++ b/exams/ckad-simulation8/solutions.md
@@ -11,13 +11,13 @@
 ### Solution
 
 ```bash
-kubectl run web --image=nginx --restart=Never --port=80 --expose -n harvest
+kubectl run web --image=nginx:1.25 --restart=Never --port=80 --expose -n harvest
 ```
 
 Or separately:
 
 ```bash
-kubectl run web --image=nginx --restart=Never --port=80 -n harvest
+kubectl run web --image=nginx:1.25 --restart=Never --port=80 -n harvest
 kubectl expose pod web --port=80 -n harvest
 ```
 
@@ -53,7 +53,7 @@ kubectl edit svc app-svc -n grain
 
 ```bash
 # Create Deployment
-kubectl create deployment backend --image=nginx --replicas=3 --port=8080 -n rice
+kubectl create deployment backend --image=nginx:1.25 --replicas=3 --port=8080 -n rice
 
 # Expose Deployment
 kubectl expose deployment backend --port=6262 --target-port=8080 -n rice
@@ -74,7 +74,7 @@ metadata:
 spec:
   containers:
   - name: nginx
-    image: nginx
+    image: nginx:1.25
     ports:
     - containerPort: 80
     readinessProbe:
@@ -98,7 +98,7 @@ metadata:
 spec:
   containers:
   - name: nginx
-    image: nginx
+    image: nginx:1.25
     livenessProbe:
       exec:
         command:
@@ -170,7 +170,7 @@ metadata:
 spec:
   containers:
   - name: nginx
-    image: nginx
+    image: nginx:1.25
     resources:
       requests:
         cpu: "0.5"
@@ -195,7 +195,7 @@ metadata:
 spec:
   containers:
   - name: nginx
-    image: nginx
+    image: nginx:1.25
     securityContext:
       capabilities:
         add:
@@ -218,13 +218,13 @@ metadata:
 spec:
   containers:
   - name: writer
-    image: busybox
+    image: busybox:1.36
     command: ["sleep", "3600"]
     volumeMounts:
     - name: shared-data
       mountPath: /data
   - name: reader
-    image: busybox
+    image: busybox:1.36
     command: ["sleep", "3600"]
     volumeMounts:
     - name: shared-data
@@ -241,7 +241,7 @@ spec:
 ### Solution
 
 ```bash
-kubectl run annotated-pod --image=nginx --restart=Never -n prosperity
+kubectl run annotated-pod --image=nginx:1.25 --restart=Never -n prosperity
 kubectl annotate pod annotated-pod owner=marketing -n prosperity
 ```
 
@@ -253,9 +253,9 @@ kubectl annotate pod annotated-pod owner=marketing -n prosperity
 
 ```bash
 # Create pods
-kubectl run pod1 --image=nginx --restart=Never -n harvest
-kubectl run pod2 --image=nginx --restart=Never -n harvest
-kubectl run pod3 --image=nginx --restart=Never -n harvest
+kubectl run pod1 --image=nginx:1.25 --restart=Never -n harvest
+kubectl run pod2 --image=nginx:1.25 --restart=Never -n harvest
+kubectl run pod3 --image=nginx:1.25 --restart=Never -n harvest
 
 # Label pods
 kubectl label pod pod1 pod2 env=prod -n harvest
@@ -383,13 +383,13 @@ metadata:
 spec:
   containers:
   - name: producer
-    image: busybox
+    image: busybox:1.36
     command: ["sleep", "3600"]
     volumeMounts:
     - name: data-volume
       mountPath: /shared
   - name: consumer
-    image: busybox
+    image: busybox:1.36
     command: ["sleep", "3600"]
     volumeMounts:
     - name: data-volume
@@ -407,13 +407,13 @@ spec:
 
 ```bash
 mkdir -p ./exam/course/18
-kubectl run busybox --rm -it --restart=Never --image=busybox -n field -- nslookup web-svc.field.svc.cluster.local | grep -A1 "Name:" | tail -1 | awk '{print $2}' > ./exam/course/18/dns.txt
+kubectl run busybox --rm -it --restart=Never --image=busybox:1.36 -n field -- nslookup web-svc.field.svc.cluster.local | grep -A1 "Name:" | tail -1 | awk '{print $2}' > ./exam/course/18/dns.txt
 ```
 
 Or:
 
 ```bash
-kubectl run busybox --rm -it --restart=Never --image=busybox -n field -- sh -c 'nslookup web-svc' > ./exam/course/18/dns.txt
+kubectl run busybox --rm -it --restart=Never --image=busybox:1.36 -n field -- sh -c 'nslookup web-svc' > ./exam/course/18/dns.txt
 ```
 
 ---

--- a/exams/ckad-simulation9/manifests/setup/q13-restart-pod.yaml
+++ b/exams/ckad-simulation9/manifests/setup/q13-restart-pod.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   containers:
   - name: app
-    image: busybox
+    image: busybox:1.36
     command: ["/bin/sh", "-c"]
     args: ["echo 'Previous instance log entry'; sleep 3; exit 1"]
     # This pod will crash and restart, creating previous logs

--- a/exams/ckad-simulation9/questions.md
+++ b/exams/ckad-simulation9/questions.md
@@ -140,7 +140,7 @@ Create a PersistentVolumeClaim named `sea-pvc` in namespace `depths` that:
 
 Create a Pod named `pvc-pod` in namespace `depths` that:
 
-- Uses image `busybox` with command `sleep 3600`
+- Uses image `busybox:1.36` with command `sleep 3600`
 - Mounts the PVC `sea-pvc` at `/data`
 
 **Hint**: Use `spec.volumes` with `persistentVolumeClaim`.
@@ -157,7 +157,7 @@ Create a Pod named `pvc-pod` in namespace `depths` that:
 
 ### Task
 
-Create a Pod named `direct-pod` in namespace `coral` with image `nginx` that is scheduled directly on a specific node using `nodeName`.
+Create a Pod named `direct-pod` in namespace `coral` with image `nginx:1.25` that is scheduled directly on a specific node using `nodeName`.
 
 Use the first node in your cluster (get it with `kubectl get nodes`).
 
@@ -175,7 +175,7 @@ Use the first node in your cluster (get it with `kubectl get nodes`).
 
 ### Task
 
-Create a Pod named `echo-pod` in namespace `current` with image `busybox` that:
+Create a Pod named `echo-pod` in namespace `current` with image `busybox:1.36` that:
 
 - Echoes "hello world"
 - Then exits
@@ -196,7 +196,7 @@ The Pod should automatically be deleted when it completes (use `--rm` if using k
 
 ### Task
 
-1. Create a Pod named `inspect-pod` with image `nginx` in namespace `abyss`
+1. Create a Pod named `inspect-pod` with image `nginx:1.25` in namespace `abyss`
 2. Export its YAML to `./exam/course/10/pod.yaml`
 
 **Hint**: Use `kubectl get pod -o yaml`.
@@ -232,7 +232,7 @@ A Pod named `problem-pod` exists in namespace `pearl` but is not running correct
 
 ### Task
 
-1. Create a Pod named `exec-pod` with image `nginx` in namespace `storm`
+1. Create a Pod named `exec-pod` with image `nginx:1.25` in namespace `storm`
 2. Execute the `hostname` command inside the Pod
 3. Save the output to `./exam/course/12/hostname.txt`
 
@@ -370,14 +370,14 @@ Create a Pod named `sidecar-pod` in namespace `abyss` with:
 **Container 1 (main):**
 
 - Name: `app`
-- Image: `busybox`
+- Image: `busybox:1.36`
 - Command: `while true; do echo "$(date)" >> /logs/app.log; sleep 5; done`
 - Mount volume at `/logs`
 
 **Container 2 (sidecar):**
 
 - Name: `sidecar`
-- Image: `busybox`
+- Image: `busybox:1.36`
 - Command: `tail -f /logs/app.log`
 - Mount same volume at `/logs`
 

--- a/exams/ckad-simulation9/solutions.md
+++ b/exams/ckad-simulation9/solutions.md
@@ -108,7 +108,7 @@ metadata:
 spec:
   containers:
   - name: busybox
-    image: busybox
+    image: busybox:1.36
     command: ["sleep", "3600"]
     volumeMounts:
     - name: data-volume
@@ -139,7 +139,7 @@ spec:
   nodeName: $NODE
   containers:
   - name: nginx
-    image: nginx
+    image: nginx:1.25
 EOF
 ```
 
@@ -149,10 +149,10 @@ EOF
 
 ```bash
 # Create Pod that echoes and exits
-kubectl run echo-pod -n current --image=busybox --restart=Never -- /bin/sh -c 'echo "hello world"'
+kubectl run echo-pod -n current --image=busybox:1.36 --restart=Never -- /bin/sh -c 'echo "hello world"'
 
 # Alternatively with --rm flag (auto-delete after completion)
-kubectl run echo-pod -n current --image=busybox --restart=Never --rm -it -- /bin/sh -c 'echo "hello world"'
+kubectl run echo-pod -n current --image=busybox:1.36 --restart=Never --rm -it -- /bin/sh -c 'echo "hello world"'
 ```
 
 ---
@@ -164,7 +164,7 @@ kubectl run echo-pod -n current --image=busybox --restart=Never --rm -it -- /bin
 mkdir -p ./exam/course/10
 
 # Create the Pod
-kubectl run inspect-pod --image=nginx -n abyss
+kubectl run inspect-pod --image=nginx:1.25 -n abyss
 
 # Export YAML
 kubectl get pod inspect-pod -n abyss -o yaml > ./exam/course/10/pod.yaml
@@ -191,7 +191,7 @@ kubectl describe pod problem-pod -n pearl | sed -n '/^Events:/,$p' > ./exam/cour
 mkdir -p ./exam/course/12
 
 # Create the Pod
-kubectl run exec-pod --image=nginx -n storm
+kubectl run exec-pod --image=nginx:1.25 -n storm
 
 # Wait for Pod to be ready
 kubectl wait --for=condition=Ready pod/exec-pod -n storm --timeout=60s
@@ -308,14 +308,14 @@ metadata:
 spec:
   containers:
   - name: app
-    image: busybox
+    image: busybox:1.36
     command: ["/bin/sh", "-c"]
     args: ["while true; do echo \"\$(date)\" >> /logs/app.log; sleep 5; done"]
     volumeMounts:
     - name: log-volume
       mountPath: /logs
   - name: sidecar
-    image: busybox
+    image: busybox:1.36
     command: ["/bin/sh", "-c"]
     args: ["tail -f /logs/app.log"]
     volumeMounts:


### PR DESCRIPTION
## Summary

- Pin all untagged container images in simulations 8 (Inari) and 9 (Ryujin) to reliable versions
- `nginx` → `nginx:1.25`, `busybox` → `busybox:1.36`
- Applied across `questions.md`, `solutions.md`, and `manifests/setup/` YAML files
- Already-tagged images (`nginx:1.18.0`, `nginx:1.19.0`, `perl:5.34`, `nginx:alpine`, etc.) preserved unchanged
- Scoring functions use wildcard matching (`*"nginx"*`) and require no changes

## Test plan

- [x] Verified no untagged images remain in sim8 and sim9 (grep check)
- [x] Verified already-tagged images are untouched
- [x] Ran `ckad-score.sh -e ckad-simulation8` — 100/104 (96%), no regression from image tag changes
- [ ] Run `ckad-score.sh -e ckad-simulation9` to confirm scoring works

🤖 Generated with [Claude Code](https://claude.com/claude-code)