### PR TITLE
docs: add CKAD curriculum coverage reference and simulation matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@
   <img src="https://img.shields.io/badge/scoring_criteria-400+-blue" alt="400+ Scoring Criteria">
   <img src="https://img.shields.io/badge/duration-120min-orange" alt="120 Minutes">
   <img src="https://img.shields.io/badge/difficulty-exam--realistic-red" alt="Exam Realistic Difficulty">
+  <a href="docs/ckad-curriculum.md"><img src="https://img.shields.io/badge/CKAD_Curriculum-v1.35-326CE5" alt="CKAD Curriculum v1.35"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-CC%20BY--NC--SA%204.0-lightgrey" alt="License: CC BY-NC-SA 4.0"></a>
   <a href="https://scorecard.dev/viewer/?uri=github.com/TiPunchLabs/ckad-dojo"><img src="https://api.scorecard.dev/projects/github.com/TiPunchLabs/ckad-dojo/badge" alt="OpenSSF Scorecard"></a>
 </p>
@@ -584,21 +585,35 @@ kubectl delete validatingwebhookconfiguration ingress-nginx-admission
 
 ---
 
-## Topics Covered
+## CKAD Curriculum Coverage
 
-- Namespaces, Pods, Jobs, Deployments
-- Helm management
-- ServiceAccounts and Secrets
-- Probes (Readiness/Liveness)
-- Rollouts and rollbacks
-- Services (ClusterIP, NodePort)
-- Storage (PV, PVC, StorageClass)
-- ConfigMaps and Secrets
-- Logging sidecars
-- InitContainers
-- NetworkPolicies
-- Resource requests and limits
-- Labels and Annotations
+Aligned with the **[official CNCF CKAD Curriculum v1.35](docs/ckad-curriculum.md)** (Kubernetes 1.35).
+
+| Domain | Weight | Coverage | Key Topics |
+|--------|:------:|:--------:|------------|
+| Application Design & Build | 20% | `██████████░░` 66% | Pods, Jobs, CronJobs, Multi-container, Volumes, Images |
+| Application Deployment | 20% | `█████████░░░` 71% | Deployments, Rollouts, Helm, Canary |
+| Observability & Maintenance | 15% | `██████████░░` 81% | Probes, Logs, Debugging, API deprecations |
+| Config & Security | 25% | `█████████░░░` 73% | ConfigMaps, Secrets, RBAC, SecurityContext, Quotas |
+| Services & Networking | 20% | `██████████░░` 84% | Services, NetworkPolicies, Ingress |
+
+<details>
+<summary><strong>Uncovered skills (priority for future simulations)</strong></summary>
+
+**Design & Build**: Multi-stage Dockerfile builds, Ambassador/Adapter patterns, ReplicaSets, hostPath volumes
+
+**Deployment**: Blue/Green strategy, Kustomize (kustomization.yaml, overlays, `kubectl apply -k`)
+
+**Observability**: Startup probes, `kubectl debug` (ephemeral containers), Node drain/cordon
+
+**Config & Security**: CRDs/Operators, docker-registry & TLS secrets, Token projection, seccompProfile
+
+**Networking**: NetworkPolicy ipBlock, Ingress TLS termination
+
+</details>
+
+> Full coverage matrix: [`docs/simulation-coverage.csv`](docs/simulation-coverage.csv)
+> Complete curriculum reference: [`docs/ckad-curriculum.md`](docs/ckad-curriculum.md)
 
 ---
 
@@ -652,6 +667,15 @@ pre-commit install --hook-type commit-msg
 | `markdownlint` | Markdown formatting |
 | `gitleaks` | Secret detection |
 | `commitizen` | Conventional commit messages |
+
+### Add a New Simulation
+
+Want to contribute a new dojo? Start here:
+
+1. Check the **[CKAD Curriculum Coverage](docs/ckad-curriculum.md)** for the official exam domains and weights
+2. Review the **[coverage matrix](docs/simulation-coverage.csv)** to identify uncovered skills (empty `covered_in` column)
+3. Aim for ~20 questions distributed across domains: Design & Build (20%), Deployment (20%), Observability (15%), Config & Security (25%), Networking (20%)
+4. Follow the existing simulation structure in `exams/ckad-simulation*/`
 
 ### Submit a Pull Request
 

--- a/docs/ckad-curriculum.md
+++ b/docs/ckad-curriculum.md
@@ -1,0 +1,237 @@
+# CKAD Official Curriculum Reference
+
+> **Source**: [CNCF Curriculum Repository](https://github.com/cncf/curriculum)
+> **File**: `CKAD_Curriculum_v1.35.pdf`
+> **Kubernetes Version**: 1.35
+> **Last Updated**: 2026-03-14
+> **Exam Duration**: 2 hours | **Questions**: 15-20 tasks | **Passing Score**: 66%
+
+------
+
+## How to Keep This Up to Date
+
+The CNCF updates the curriculum when a new Kubernetes minor version is released (usually every ~4 months). The exam environment aligns with the latest K8s minor within 4-8 weeks of release.
+
+| Source | URL | What to Watch |
+|--------|-----|---------------|
+| CNCF Curriculum (GitHub) | https://github.com/cncf/curriculum | Watch repo for commits on CKAD files |
+| Linux Foundation CKAD | https://training.linuxfoundation.org/certification/certified-kubernetes-application-developer-ckad/ | K8s version updates, exam format changes |
+| CNCF Certification Page | https://www.cncf.io/training/certification/ckad/ | Official announcements |
+
+When the curriculum changes:
+
+1. Check for a new `CKAD_Curriculum_v1.XX.pdf` in the CNCF repo
+2. Compare domains/competencies with the tables below
+3. Update this file and `docs/simulation-coverage.csv`
+4. Open an issue to track any new competencies that need simulation coverage
+
+------
+
+## Official Domains and Competencies (5 domains, 22 competencies)
+
+### 1. Application Design and Build — 20%
+
+| ID | Competency |
+|----|------------|
+| DB-01 | Define, build and modify container images |
+| DB-02 | Choose and use the right workload resource (Deployment, DaemonSet, CronJob, etc.) |
+| DB-03 | Understand multi-container Pod design patterns (e.g. sidecar, init and others) |
+| DB-04 | Utilize persistent and ephemeral volumes |
+
+### 2. Application Deployment — 20%
+
+| ID | Competency |
+|----|------------|
+| AD-01 | Use Kubernetes primitives to implement common deployment strategies (e.g. blue/green or canary) |
+| AD-02 | Understand Deployments and how to perform rolling updates |
+| AD-03 | Use the Helm package manager to deploy existing packages |
+| AD-04 | Kustomize |
+
+### 3. Application Observability and Maintenance — 15%
+
+| ID | Competency |
+|----|------------|
+| OM-01 | Understand API deprecations |
+| OM-02 | Implement probes and health checks |
+| OM-03 | Use built-in CLI tools to monitor Kubernetes applications |
+| OM-04 | Utilize container logs |
+| OM-05 | Debugging in Kubernetes |
+
+### 4. Application Environment, Configuration and Security — 25%
+
+| ID | Competency |
+|----|------------|
+| CS-01 | Discover and use resources that extend Kubernetes (CRD, Operators) |
+| CS-02 | Understand authentication, authorization and admission control |
+| CS-03 | Understand requests, limits, quotas |
+| CS-04 | Understand ConfigMaps |
+| CS-05 | Create and consume Secrets |
+| CS-06 | Understand ServiceAccounts |
+| CS-07 | Understand Application Security (SecurityContexts, Capabilities, etc.) |
+
+### 5. Services and Networking — 20%
+
+| ID | Competency |
+|----|------------|
+| SN-01 | Demonstrate basic understanding of NetworkPolicies |
+| SN-02 | Provide and troubleshoot access to applications via services |
+| SN-03 | Use Ingress rules to expose applications |
+
+------
+
+## Competency Breakdown into Testable Skills
+
+Each official competency maps to concrete skills that can be tested in simulations.
+
+### DB-01: Container Images
+
+- Build images with Dockerfile
+- Multi-stage Dockerfile builds
+- Modify/tag existing images
+- Push to local registry
+
+### DB-02: Workload Resources
+
+- Deployments (create, scale, update)
+- DaemonSets
+- CronJobs / Jobs (completions, parallelism, activeDeadlineSeconds)
+- StatefulSets
+- ReplicaSets
+
+### DB-03: Multi-container Patterns
+
+- Sidecar containers
+- Init containers (single and multiple)
+- Ambassador pattern
+- Adapter pattern
+
+### DB-04: Volumes
+
+- PersistentVolumes / PersistentVolumeClaims
+- emptyDir (shared between containers)
+- hostPath
+- ConfigMap/Secret as volumes
+
+### AD-01: Deployment Strategies
+
+- Blue/Green deployment
+- Canary deployment
+- Rollback to specific revision
+
+### AD-02: Rolling Updates
+
+- Rolling update strategy (maxSurge, maxUnavailable)
+- Rollout history / undo
+- Pause/resume rollouts
+
+### AD-03: Helm
+
+- Install/upgrade/rollback releases
+- Search and add repositories
+- Inspect values
+- Create charts (helm create)
+- Template rendering
+
+### AD-04: Kustomize
+
+- kustomization.yaml
+- Overlays and patches
+- kubectl apply -k
+
+### OM-01: API Deprecations
+
+- Identify deprecated API versions
+- Migrate resources to current API versions
+
+### OM-02: Probes and Health Checks
+
+- Liveness probes (httpGet, tcpSocket, exec)
+- Readiness probes
+- Startup probes
+- Probe parameters (initialDelaySeconds, periodSeconds, etc.)
+
+### OM-03: CLI Monitoring Tools
+
+- kubectl top (pods, nodes)
+- kubectl describe (events)
+- kubectl get (wide output, custom columns)
+- kubectl debug (ephemeral containers)
+
+### OM-04: Container Logs
+
+- kubectl logs (current, previous)
+- Multi-container log selection (-c)
+
+### OM-05: Debugging
+
+- Troubleshoot CrashLoopBackOff
+- Troubleshoot ImagePullBackOff
+- kubectl exec into containers
+- Events analysis
+- Node drain/cordon
+
+### CS-01: CRDs and Operators
+
+- Discover CRDs (kubectl get crd)
+- Use custom resources
+
+### CS-02: Auth and Admission Control
+
+- RBAC (Roles, RoleBindings, ClusterRoles, ClusterRoleBindings)
+- kubectl auth can-i
+- ServiceAccount token mounting
+
+### CS-03: Requests, Limits, Quotas
+
+- Resource requests and limits (cpu, memory)
+- LimitRange
+- ResourceQuota
+- Troubleshoot quota violations
+
+### CS-04: ConfigMaps
+
+- Create from literal, file, env-file
+- Mount as volume
+- Use as environment variables (envFrom, valueFrom)
+
+### CS-05: Secrets
+
+- Create generic, docker-registry, tls secrets
+- Mount as volume
+- Use as environment variables (secretKeyRef)
+- Base64 encode/decode
+
+### CS-06: ServiceAccounts
+
+- Create and assign to pods
+- Token projection
+- Automount control
+
+### CS-07: Application Security
+
+- SecurityContext (runAsUser, runAsGroup, runAsNonRoot, fsGroup)
+- Capabilities (add/drop)
+- seccompProfile
+- readOnlyRootFilesystem
+
+### SN-01: NetworkPolicies
+
+- Ingress rules (podSelector, namespaceSelector, ipBlock)
+- Egress rules
+- Default deny policies
+- Label-based selection
+
+### SN-02: Services
+
+- ClusterIP, NodePort, LoadBalancer
+- ExternalName services
+- Service selector troubleshooting
+- kubectl expose
+- DNS resolution
+
+### SN-03: Ingress
+
+- Path-based routing
+- Host-based routing
+- TLS termination
+- Ingress controller troubleshooting

--- a/docs/simulation-coverage.csv
+++ b/docs/simulation-coverage.csv
@@ -1,0 +1,85 @@
+id,domain,weight,competency,skill,covered_in
+DB-01,Application Design and Build,20%,Define build and modify container images,Build images with Dockerfile,"sim1,sim10"
+DB-01,Application Design and Build,20%,Define build and modify container images,Multi-stage Dockerfile builds,
+DB-01,Application Design and Build,20%,Define build and modify container images,Modify/tag existing images,"sim10"
+DB-01,Application Design and Build,20%,Define build and modify container images,Push to local registry,"sim10"
+DB-02,Application Design and Build,20%,Choose and use the right workload resource,Deployments (create/scale/update),"sim1,sim2,sim3,sim5,sim6,sim7,sim8,sim10"
+DB-02,Application Design and Build,20%,Choose and use the right workload resource,DaemonSets,"sim3"
+DB-02,Application Design and Build,20%,Choose and use the right workload resource,CronJobs/Jobs,"sim1,sim4,sim5,sim6,sim7,sim9,sim10"
+DB-02,Application Design and Build,20%,Choose and use the right workload resource,StatefulSets,"sim3"
+DB-02,Application Design and Build,20%,Choose and use the right workload resource,ReplicaSets,
+DB-03,Application Design and Build,20%,Understand multi-container Pod design patterns,Sidecar containers,"sim9,sim10"
+DB-03,Application Design and Build,20%,Understand multi-container Pod design patterns,Init containers,"sim1,sim6"
+DB-03,Application Design and Build,20%,Understand multi-container Pod design patterns,Multiple init containers,
+DB-03,Application Design and Build,20%,Understand multi-container Pod design patterns,Ambassador pattern,
+DB-03,Application Design and Build,20%,Understand multi-container Pod design patterns,Adapter pattern,
+DB-04,Application Design and Build,20%,Utilize persistent and ephemeral volumes,PersistentVolumes/PersistentVolumeClaims,"sim1,sim4,sim6,sim9"
+DB-04,Application Design and Build,20%,Utilize persistent and ephemeral volumes,emptyDir,"sim5,sim8"
+DB-04,Application Design and Build,20%,Utilize persistent and ephemeral volumes,hostPath,
+DB-04,Application Design and Build,20%,Utilize persistent and ephemeral volumes,ConfigMap/Secret as volumes,"sim1,sim5,sim6,sim8"
+AD-01,Application Deployment,20%,Common deployment strategies,Blue/Green deployment,
+AD-01,Application Deployment,20%,Common deployment strategies,Canary deployment,"sim8,sim10"
+AD-01,Application Deployment,20%,Common deployment strategies,Rollback to specific revision,"sim9,sim10"
+AD-02,Application Deployment,20%,Deployments and rolling updates,Rolling update strategy (maxSurge/maxUnavailable),"sim10"
+AD-02,Application Deployment,20%,Deployments and rolling updates,Rollout history/undo,"sim1,sim4,sim7,sim10"
+AD-02,Application Deployment,20%,Deployments and rolling updates,Pause/resume rollouts,"sim7"
+AD-03,Application Deployment,20%,Helm package manager,Install/upgrade/rollback releases,"sim1,sim9"
+AD-03,Application Deployment,20%,Helm package manager,Search and add repositories,"sim8"
+AD-03,Application Deployment,20%,Helm package manager,Inspect values,"sim8"
+AD-03,Application Deployment,20%,Helm package manager,Create charts (helm create),"sim9"
+AD-03,Application Deployment,20%,Helm package manager,Template rendering,"sim9"
+AD-04,Application Deployment,20%,Kustomize,kustomization.yaml,
+AD-04,Application Deployment,20%,Kustomize,Overlays and patches,
+AD-04,Application Deployment,20%,Kustomize,kubectl apply -k,
+OM-01,Application Observability and Maintenance,15%,Understand API deprecations,Identify deprecated API versions,"sim10"
+OM-01,Application Observability and Maintenance,15%,Understand API deprecations,Migrate resources to current API versions,"sim10"
+OM-02,Application Observability and Maintenance,15%,Implement probes and health checks,Liveness probes,"sim1,sim2,sim6,sim8"
+OM-02,Application Observability and Maintenance,15%,Implement probes and health checks,Readiness probes,"sim1,sim8"
+OM-02,Application Observability and Maintenance,15%,Implement probes and health checks,Startup probes,
+OM-02,Application Observability and Maintenance,15%,Implement probes and health checks,Probe parameters,"sim1,sim6"
+OM-03,Application Observability and Maintenance,15%,CLI monitoring tools,kubectl top,"sim9"
+OM-03,Application Observability and Maintenance,15%,CLI monitoring tools,kubectl describe/events,"sim4,sim9,sim10"
+OM-03,Application Observability and Maintenance,15%,CLI monitoring tools,kubectl debug (ephemeral containers),
+OM-04,Application Observability and Maintenance,15%,Utilize container logs,kubectl logs (current/previous),"sim1,sim4,sim7,sim9"
+OM-04,Application Observability and Maintenance,15%,Utilize container logs,Multi-container log selection,"sim5"
+OM-05,Application Observability and Maintenance,15%,Debugging in Kubernetes,Troubleshoot CrashLoopBackOff,"sim10"
+OM-05,Application Observability and Maintenance,15%,Debugging in Kubernetes,Troubleshoot ImagePullBackOff,"sim3,sim4"
+OM-05,Application Observability and Maintenance,15%,Debugging in Kubernetes,kubectl exec,"sim5,sim9"
+OM-05,Application Observability and Maintenance,15%,Debugging in Kubernetes,Events analysis,"sim4,sim9,sim10"
+OM-05,Application Observability and Maintenance,15%,Debugging in Kubernetes,Node drain/cordon,
+CS-01,Application Environment Configuration and Security,25%,CRDs and Operators,Discover CRDs (kubectl get crd),
+CS-01,Application Environment Configuration and Security,25%,CRDs and Operators,Use custom resources,
+CS-02,Application Environment Configuration and Security,25%,Authentication authorization and admission control,RBAC (Roles/RoleBindings/ClusterRoles),"sim3,sim10"
+CS-02,Application Environment Configuration and Security,25%,Authentication authorization and admission control,kubectl auth can-i,"sim10"
+CS-02,Application Environment Configuration and Security,25%,Authentication authorization and admission control,ServiceAccount token mounting,"sim8"
+CS-03,Application Environment Configuration and Security,25%,Requests limits quotas,Resource requests and limits,"sim2,sim3,sim6,sim10"
+CS-03,Application Environment Configuration and Security,25%,Requests limits quotas,LimitRange,"sim2,sim8"
+CS-03,Application Environment Configuration and Security,25%,Requests limits quotas,ResourceQuota,"sim3,sim5,sim10"
+CS-03,Application Environment Configuration and Security,25%,Requests limits quotas,Troubleshoot quota violations,"sim10"
+CS-04,Application Environment Configuration and Security,25%,Understand ConfigMaps,Create from literal/file/env-file,"sim1,sim5,sim6,sim7,sim9"
+CS-04,Application Environment Configuration and Security,25%,Understand ConfigMaps,Mount as volume,"sim5,sim6"
+CS-04,Application Environment Configuration and Security,25%,Understand ConfigMaps,Use as environment variables (envFrom/valueFrom),"sim1,sim7,sim10"
+CS-05,Application Environment Configuration and Security,25%,Create and consume Secrets,Create generic secrets,"sim1,sim4,sim5,sim6,sim10"
+CS-05,Application Environment Configuration and Security,25%,Create and consume Secrets,Create docker-registry secrets,
+CS-05,Application Environment Configuration and Security,25%,Create and consume Secrets,Create tls secrets,
+CS-05,Application Environment Configuration and Security,25%,Create and consume Secrets,Mount as volume/env (secretKeyRef),"sim1,sim5,sim6,sim10"
+CS-06,Application Environment Configuration and Security,25%,Understand ServiceAccounts,Create and assign to pods,"sim1,sim4,sim8"
+CS-06,Application Environment Configuration and Security,25%,Understand ServiceAccounts,Token projection,
+CS-06,Application Environment Configuration and Security,25%,Understand ServiceAccounts,Automount control,"sim2"
+CS-07,Application Environment Configuration and Security,25%,Application Security,SecurityContext (runAsUser/runAsGroup/runAsNonRoot),"sim2,sim6,sim10"
+CS-07,Application Environment Configuration and Security,25%,Application Security,Capabilities (add/drop),"sim2,sim8"
+CS-07,Application Environment Configuration and Security,25%,Application Security,seccompProfile,
+CS-07,Application Environment Configuration and Security,25%,Application Security,readOnlyRootFilesystem,"sim2"
+SN-01,Services and Networking,20%,Understand NetworkPolicies,Ingress rules (podSelector/namespaceSelector),"sim1,sim5,sim6,sim8,sim10"
+SN-01,Services and Networking,20%,Understand NetworkPolicies,Egress rules,"sim5"
+SN-01,Services and Networking,20%,Understand NetworkPolicies,Default deny policies,"sim5"
+SN-01,Services and Networking,20%,Understand NetworkPolicies,NetworkPolicy ipBlock,
+SN-02,Services and Networking,20%,Access to applications via services,ClusterIP/NodePort/LoadBalancer,"sim1,sim4,sim7,sim8,sim10"
+SN-02,Services and Networking,20%,Access to applications via services,ExternalName services,"sim2"
+SN-02,Services and Networking,20%,Access to applications via services,Service selector troubleshooting,"sim10"
+SN-02,Services and Networking,20%,Access to applications via services,kubectl expose,"sim5,sim7,sim10"
+SN-02,Services and Networking,20%,Access to applications via services,DNS resolution,"sim8"
+SN-03,Services and Networking,20%,Ingress rules to expose applications,Path-based routing,"sim10"
+SN-03,Services and Networking,20%,Ingress rules to expose applications,Host-based routing,"sim10"
+SN-03,Services and Networking,20%,Ingress rules to expose applications,TLS termination,
+SN-03,Services and Networking,20%,Ingress rules to expose applications,Ingress controller troubleshooting,"sim10"


### PR DESCRIPTION
## Summary

- Add official CNCF CKAD Curriculum v1.35 reference (`docs/ckad-curriculum.md`) with 5 domains, 22 competencies, and 84 testable skills
- Add full coverage matrix (`docs/simulation-coverage.csv`) tracking which skills are covered by which simulation
- Replace flat "Topics Covered" README section with curriculum-aligned coverage table showing per-domain progress bars and identified gaps
- Add "Add a New Simulation" contributor guide pointing to curriculum and coverage matrix

## Why

The project had no formal link to the official CKAD exam curriculum. Contributors had no way to know which skills were covered, which were missing, or how to distribute questions across domains. This makes the project's alignment with the real exam visible and actionable.

## Key files

| File | Purpose |
|------|---------|
| `docs/ckad-curriculum.md` | Official CNCF curriculum (5 domains, 22 competencies, 84 skills) |
| `docs/simulation-coverage.csv` | Coverage matrix — 84 skills x 10 simulations |
| `README.md` | Badge, coverage table, gaps, contributor guide |

## Test plan

- [x] Verify badge renders correctly on GitHub
- [x] Verify coverage table renders with progress bars in README
- [x] Verify collapsible "Uncovered skills" section works
- [x] Verify CSV is parseable and data matches actual simulation content
- [x] Verify links to docs files work from README

🤖 Generated with [Claude Code](https://claude.com/claude-code)