### PR TITLE
docs: add QUICKSTART.md with 3-step onboarding

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -1,0 +1,52 @@
+# 🥋 Démarrer avec ckad-dojo en 3 étapes
+
+![Kubernetes 1.28+](https://img.shields.io/badge/Kubernetes-1.28+-326CE5?logo=kubernetes&logoColor=white)
+![kubectl](https://img.shields.io/badge/kubectl-required-326CE5)
+![helm 3.x](https://img.shields.io/badge/helm-3.x-0F1689?logo=helm&logoColor=white)
+![docker 20.x+](https://img.shields.io/badge/docker-20.x+-2496ED?logo=docker&logoColor=white)
+![ttyd 1.7+](https://img.shields.io/badge/ttyd-1.7+-black)
+![Setup ~5 min](https://img.shields.io/badge/setup-~5_min-brightgreen)
+
+---
+
+## Étape 1 — Prérequis
+
+Un cluster Kubernetes fonctionnel + les outils suivants installés :
+
+```bash
+kubectl cluster-info && helm version && docker --version && ttyd --version
+```
+
+Si une commande échoue, installez l'outil manquant. Détails : [README.md#prerequisites](README.md#prerequisites).
+
+---
+
+## Étape 2 — Installer et lancer
+
+```bash
+git clone https://github.com/TiPunchLabs/ckad-dojo.git && cd ckad-dojo
+curl -LsSf https://astral.sh/uv/install.sh | sh
+uv run ckad-dojo
+```
+
+Le menu interactif s'affiche. L'interface web s'ouvre sur `http://localhost:9090`.
+
+---
+
+## Étape 3 — Commencer l'examen
+
+Choisissez un dojo dans le menu, ou lancez directement :
+
+```bash
+uv run ckad-dojo exam start -e ckad-simulation1
+```
+
+Timer 120 min. Terminal kubectl intégré. Scoring automatique.
+
+---
+
+## Et ensuite ?
+
+- **Vérifier votre score** : `uv run ckad-dojo score -e ckad-simulation1`
+- **10 dojos disponibles** (198 questions) — voir la [liste complète](README.md#the-ten-dojos)
+- **Full guide** : [README.md](README.md)

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -25,6 +25,7 @@ Si une commande échoue, installez l'outil manquant. Détails : [README.md#prere
 
 ```bash
 git clone https://github.com/TiPunchLabs/ckad-dojo.git && cd ckad-dojo
+direnv allow   # if you use direnv (otherwise ignore)
 curl -LsSf https://astral.sh/uv/install.sh | sh
 uv run ckad-dojo
 ```

--- a/README.md
+++ b/README.md
@@ -128,21 +128,12 @@ Three dojos are themed after the Shishin (四神) — Celestial Guardians from E
 
 ## 🚀 Quick Start (5 minutes)
 
-> ⚠️ **Requires** a running Kubernetes cluster, `kubectl`, `helm`, `docker`, and `ttyd`. See [Prerequisites](#prerequisites) for details.
-
-Get your first exam running in under 5 minutes:
+> **New here?** See the [QUICKSTART.md](QUICKSTART.md) — 3 steps, zero fluff.
 
 ```bash
-# 1. Install uv (Python package manager)
-curl -LsSf https://astral.sh/uv/install.sh | sh
-
-# 2. Clone and launch
-git clone https://github.com/TiPunchLabs/ckad-dojo.git
-cd ckad-dojo
+git clone https://github.com/TiPunchLabs/ckad-dojo.git && cd ckad-dojo
 uv run ckad-dojo
 ```
-
-That's it. The interactive menu guides you from there. Opens `http://localhost:9090` with timer, questions, and embedded terminal.
 
 > **Already cloned?** Just run `uv run ckad-dojo` from the repo directory.
 


### PR DESCRIPTION
## Summary
- Add `QUICKSTART.md` with a 3-step guide (prerequisites check, install & launch, start exam) to reduce onboarding friction
- Simplify the README Quick Start section to link to the new QUICKSTART.md instead of duplicating instructions

## Test plan
- [x] Verify QUICKSTART.md renders correctly on GitHub (badges, code blocks, links)
- [x] Verify README Quick Start section links to QUICKSTART.md correctly
- [x] Confirm all commands in QUICKSTART.md work on a fresh clone

🤖 Generated with [Claude Code](https://claude.com/claude-code)