### PR TITLE
fix: include ckad_dojo.py in wheel build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
-packages = ["web"]
+packages = ["web", "ckad_dojo.py"]
 
 [tool.ruff]
 target-version = "py310"


### PR DESCRIPTION
## Summary
- Fix `No module named 'ckad_dojo'` when installed via `uv tool install`
- Add `ckad_dojo.py` to hatch wheel build config alongside `web/`

**Root cause:** `[tool.hatch.build.targets.wheel]` only listed `packages = ["web"]`, so the CLI entrypoint module was excluded from the wheel.

Fixes #61

## Test plan
- [x] `uv build --wheel` includes `ckad_dojo.py` in the wheel
- [x] `uv tool install .` succeeds and `ckad-dojo --version` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)