### PR TITLE
fix(cleanup): add ClusterRole/ClusterRoleBinding cleanup to exam reset

### DIFF
--- a/scripts/ckad-cleanup.sh
+++ b/scripts/ckad-cleanup.sh
@@ -29,8 +29,9 @@ show_help() {
 	echo "  2. Uninstall Helm releases"
 	echo "  3. Clean up resources in default namespace"
 	echo "  4. Delete all exam namespaces"
-	echo "  5. Remove ./exam/course/ directory"
-	echo "  6. Stop and remove local Docker registry"
+	echo "  5. Clean up cluster-scoped resources (PVs, StorageClasses, ClusterRoles)"
+	echo "  6. Remove ./exam/course/ directory"
+	echo "  7. Stop and remove local Docker registry"
 	echo ""
 	echo "WARNING: This will delete all exam resources!"
 }
@@ -175,27 +176,30 @@ main() {
 	# Step 5: Clean up custom StorageClasses (cluster-scoped)
 	cleanup_storage_classes
 
-	# Step 6: Remove exam directories
+	# Step 6: Clean up ClusterRoles and ClusterRoleBindings (cluster-scoped)
+	cleanup_cluster_roles
+
+	# Step 7: Remove exam directories
 	if [ "$KEEP_DIRS" = false ]; then
 		cleanup_directories
 	else
 		print_section "Keeping exam directories (--keep-dirs)"
 	fi
 
-	# Step 7: Stop registry
+	# Step 8: Stop registry
 	if [ "$KEEP_REGISTRY" = false ]; then
 		cleanup_registry
 	else
 		print_section "Keeping local registry (--keep-registry)"
 	fi
 
-	# Step 8: Clean up exam Docker containers
+	# Step 9: Clean up exam Docker containers
 	cleanup_docker_containers
 
-	# Step 9: Clean up exam Docker images (localhost:5000/*)
+	# Step 10: Clean up exam Docker images (localhost:5000/*)
 	cleanup_docker_images
 
-	# Step 10: Reset timer state
+	# Step 11: Reset timer state
 	timer_reset 2>/dev/null || true
 
 	# Wait for namespace deletion

--- a/scripts/lib/setup-functions.sh
+++ b/scripts/lib/setup-functions.sh
@@ -657,6 +657,39 @@ cleanup_storage_classes() {
 	fi
 }
 
+# Clean up ClusterRoles and ClusterRoleBindings created during exam
+cleanup_cluster_roles() {
+	print_section "Cleaning up ClusterRoles and ClusterRoleBindings..."
+
+	local deleted=0
+
+	# Known exam ClusterRole/ClusterRoleBinding names from scoring functions
+	local exam_cr_names=("node-reader" "healthz-access")
+	local exam_crb_names=("node-reader-binding" "healthz-access-binding")
+
+	# Delete matching ClusterRoles
+	for cr_name in "${exam_cr_names[@]}"; do
+		if kubectl get clusterrole "$cr_name" &>/dev/null; then
+			kubectl delete clusterrole "$cr_name" 2>/dev/null || true
+			print_success "Deleted ClusterRole: $cr_name"
+			((++deleted))
+		fi
+	done
+
+	# Delete matching ClusterRoleBindings
+	for crb_name in "${exam_crb_names[@]}"; do
+		if kubectl get clusterrolebinding "$crb_name" &>/dev/null; then
+			kubectl delete clusterrolebinding "$crb_name" 2>/dev/null || true
+			print_success "Deleted ClusterRoleBinding: $crb_name"
+			((++deleted))
+		fi
+	done
+
+	if [ $deleted -eq 0 ]; then
+		print_skip "No exam ClusterRoles/ClusterRoleBindings found"
+	fi
+}
+
 # Wait for namespace deletion to complete
 wait_for_namespace_deletion() {
 	print_section "Waiting for namespace deletion..."


### PR DESCRIPTION
## Summary
- Add `cleanup_cluster_roles()` function to delete cluster-scoped RBAC resources (ClusterRole, ClusterRoleBinding) created by users during exam answers
- Integrate as step 6 in `ckad-cleanup.sh` between StorageClasses cleanup and directory removal
- Affected simulations: sim5 Q18 (`node-reader`/`node-reader-binding`), local-4 Q15 (`healthz-access`/`healthz-access-binding`)

## Context
The cleanup script already handled PersistentVolumes and StorageClasses (cluster-scoped), but ClusterRole/ClusterRoleBinding were missing. These resources persisted across exam runs, polluting the cluster.

## Test plan
- [ ] Run `ckad-setup.sh -e ckad-simulation5` then answer Q18 (create ClusterRole/ClusterRoleBinding)
- [ ] Run `ckad-cleanup.sh -e ckad-simulation5` and verify `kubectl get clusterrole node-reader` returns "not found"
- [ ] Run `ckad-cleanup.sh` on a simulation without RBAC questions — verify "No exam ClusterRoles/ClusterRoleBindings found" is shown
- [ ] `shellcheck --severity=warning scripts/lib/setup-functions.sh` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)