### PR TITLE
docs: add demo video to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,8 @@
 
 
 
-![](./img/ckad-dojo.png)
-
 <p align="center">
-  <video src="https://github.com/user-attachments/assets/c0191341-4dd0-4e2c-aea7-3a6858ab1271" controls width="800"></video>
+  <video src="https://github.com/user-attachments/assets/a3c91238-b7ad-4433-b61c-4aa9663e85ce" controls width="800"></video>
 </p>
 
 ## Overview

--- a/README.md
+++ b/README.md
@@ -48,7 +48,9 @@
 
 ![](./img/ckad-dojo.png)
 
-
+<p align="center">
+  <video src="https://github.com/user-attachments/assets/c0191341-4dd0-4e2c-aea7-3a6858ab1271" controls width="800"></video>
+</p>
 
 ## Overview
 


### PR DESCRIPTION
## Summary
- Embed demo video (ckad-dojo.webm) in README below the screenshot
- Video hosted via GitHub assets (no binary in repo)
- Closes #69

## Test plan
- [x] Verify video renders on the PR preview
- [x] Verify playback controls work on github.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)