### PR TITLE
fix(sim6): score Q5 image via rollout history to tolerate Q6 mutation

### DIFF
--- a/exams/ckad-simulation6/scoring-functions.sh
+++ b/exams/ckad-simulation6/scoring-functions.sh
@@ -185,14 +185,15 @@ score_q5() {
 		((score += 2))
 		details+="Deployment nginx-deploy exists. "
 
-		# Check image
-		local image
-		image=$(kubectl get deployment nginx-deploy -n valley -o jsonpath='{.spec.template.spec.containers[0].image}' 2>/dev/null)
-		if [[ "$image" == "nginx:1.18.0" ]]; then
+		# Q6 mutates this deployment's image, so accept current spec OR revision 1
+		local image_current image_rev1
+		image_current=$(kubectl get deployment nginx-deploy -n valley -o jsonpath='{.spec.template.spec.containers[0].image}' 2>/dev/null)
+		image_rev1=$(kubectl rollout history deployment nginx-deploy -n valley --revision=1 2>/dev/null | awk '/Image:/ {print $2; exit}')
+		if [[ "$image_current" == "nginx:1.18.0" || "$image_rev1" == "nginx:1.18.0" ]]; then
 			((score += 2))
-			details+="Image is nginx:1.18.0. "
+			details+="Image nginx:1.18.0 (rev1=$image_rev1, current=$image_current). "
 		else
-			details+="Image is $image (expected nginx:1.18.0). "
+			details+="Image nginx:1.18.0 not found (rev1=$image_rev1, current=$image_current). "
 		fi
 
 		# Check replicas


### PR DESCRIPTION
Fixes #77

## Root cause
`score_q5()` reads `.spec.template.spec.containers[0].image` against the live cluster state. Q5 creates `nginx-deploy` at `nginx:1.18.0`, Q6 mutates the same Deployment to `nginx:1.19.8`. A user who completes both questions in the natural order ends up with `current=1.19.8`, so the Q5 image check fails and 2 points are docked. Q5 scores 4/6 instead of 6/6.

## Fix
`score_q5` now accepts either the current spec image OR the image recorded in rollout revision 1.

```bash
local image_current image_rev1
image_current=$(kubectl get deployment nginx-deploy -n valley \
  -o jsonpath='{.spec.template.spec.containers[0].image}' 2>/dev/null)
image_rev1=$(kubectl rollout history deployment nginx-deploy -n valley --revision=1 2>/dev/null \
  | awk '/Image:/ {print $2; exit}')
if [[ "$image_current" == "nginx:1.18.0" || "$image_rev1" == "nginx:1.18.0" ]]; then
    ((score += 2))
    details+="Image nginx:1.18.0 (rev1=$image_rev1, current=$image_current). "
else
    details+="Image nginx:1.18.0 not found (rev1=$image_rev1, current=$image_current). "
fi
```

Why this approach (vs Q6 doing `rollout undo`, or decoupling resources):
- Preserves the Q5→Q6→Q7 narrative on a single Deployment.
- Robust regardless of question order.
- Tests a real CKAD skill (`kubectl rollout history --revision=N`).
- No edits to `questions.md`, `solutions.md`, or `post-setup.sh`.
- No false positives — if a user skips Q5 and creates the Deployment directly at `1.19.8`, both `rev1` and `current` report `1.19.8` and Q5 still fails the image check.

## Validation
**Static**: `bash -n`, `shellcheck --severity=warning`, `./tests/run-tests.sh` (52 tests / 5 suites) → all PASS.

**Live replay** on a 3-node Kubernetes v1.34.3 cluster:
- Setup → baseline score 3/106 (Q7 partial from pre-setup)
- Executed all 20 official solutions in order (Q5 creates at `1.18.0`, Q6 mutates to `1.19.8`)
- Final cluster state confirmed: `current=nginx:1.19.8`, `rev1=nginx:1.18.0`, `rev2=nginx:1.19.8`
- Final score: **106/106 (100%)**
- Q5 DETAILS line: `Image nginx:1.18.0 (rev1=nginx:1.18.0, current=nginx:1.19.8)` — fallback path exercised
- Cleanup left zero exam namespaces and zero orphan PVs

## Out of scope
While replaying I hit a separate coupling bug — Q3 creates a ResourceQuota on `cliff` requiring CPU/memory specs, but Q14's official `vol-pod` solution omits resources and gets quota-rejected. Will open a follow-up issue.

## Test plan
- [x] `./scripts/ckad-setup.sh -e ckad-simulation6`
- [x] Run Q5 only → `./scripts/ckad-score.sh -e ckad-simulation6` shows `Q5 6/6` (no regression)
- [x] Run Q5 then Q6 → `./scripts/ckad-score.sh -e ckad-simulation6` shows `Q5 6/6` and `Q6 5/5` (the fix)
- [x] Skip Q5, create `nginx-deploy` directly at `nginx:1.19.8` → Q5 image check fails as expected (no false positive)
- [x] `./scripts/ckad-cleanup.sh -e ckad-simulation6 -y` leaves no residue

🤖 Generated with [Claude Code](https://claude.com/claude-code)