### PR TITLE
fix(readme): use bare URL so GitHub auto-renders the demo video

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,7 @@
 
 
 
-<p align="center">
-  <video src="https://github.com/user-attachments/assets/a3c91238-b7ad-4433-b61c-4aa9663e85ce" controls width="800"></video>
-</p>
+https://github.com/user-attachments/assets/a3c91238-b7ad-4433-b61c-4aa9663e85ce
 
 ## Overview
 

--- a/README.md
+++ b/README.md
@@ -38,9 +38,8 @@
 
 ---
 
+[Capture vidéo du 2026-04-11 12-09-26.webm](https://github.com/user-attachments/assets/246fc11f-9fbc-4c38-96e1-0b2991326ddf)
 
-
-https://github.com/user-attachments/assets/a3c91238-b7ad-4433-b61c-4aa9663e85ce
 
 ## Overview
 


### PR DESCRIPTION
## Summary
- The demo video in the README rendered as an empty/broken player because GitHub's Markdown sanitizer strips the `src` attribute from `<video>` tags.
- Replaced the `<video src="...">` markup with a bare `user-attachments` URL on its own line — GitHub auto-converts that into an HTML5 video embed with native controls.

## Test plan
- [ ] Open the PR on GitHub and confirm the README preview shows a working video player at the top.
- [ ] Verify on mobile rendering (responsive width handled by GitHub).
- [ ] Confirm no other layout regression around the Overview section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)