### PR TITLE
feat: add CNCF domain mapping to dojo Oni

### DIFF
--- a/exams/ckad-simulation10/questions.md
+++ b/exams/ckad-simulation10/questions.md
@@ -21,6 +21,8 @@
 | | |
 |---|---|
 | **Points** | 5 |
+| **CNCF Domain** | Application Environment, Configuration and Security |
+| **CNCF Weight** | 25% |
 | **Namespace** | `fortress` |
 | **Resources** | Pod `webapp` |
 
@@ -41,6 +43,8 @@ The Pod must be running with the environment variables sourced from the Secret.
 | | |
 |---|---|
 | **Points** | 6 |
+| **CNCF Domain** | Services and Networking |
+| **CNCF Weight** | 20% |
 | **Namespace** | `bastion` |
 | **Resources** | Deployment `frontend`, Service `frontend-svc`, Ingress `frontend-ingress` |
 
@@ -64,6 +68,8 @@ Inspect the existing Service and Ingress, identify the problems, and fix the Ing
 | | |
 |---|---|
 | **Points** | 5 |
+| **CNCF Domain** | Services and Networking |
+| **CNCF Weight** | 20% |
 | **Namespace** | `citadel` |
 | **Resources** | Deployment `api-server`, Service `api-svc` |
 
@@ -84,6 +90,8 @@ Create an Ingress named `api-ingress` in namespace `citadel` that:
 | | |
 |---|---|
 | **Points** | 6 |
+| **CNCF Domain** | Services and Networking |
+| **CNCF Weight** | 20% |
 | **Namespace** | `rampart` |
 | **Resources** | Pods `frontend`, `backend`, `database`; NetworkPolicies `default-deny`, `allow-frontend-to-backend`, `allow-backend-to-db` |
 
@@ -109,6 +117,8 @@ Instead:
 | | |
 |---|---|
 | **Points** | 5 |
+| **CNCF Domain** | Application Environment, Configuration and Security |
+| **CNCF Weight** | 25% |
 | **Namespace** | `tower` |
 | **Resources** | Deployment `compute-app` |
 
@@ -130,6 +140,8 @@ The Deployment must have running Pods after the update.
 | | |
 |---|---|
 | **Points** | 5 |
+| **CNCF Domain** | Application Environment, Configuration and Security |
+| **CNCF Weight** | 25% |
 | **Namespace** | `garrison` |
 | **Resources** | ResourceQuota `compute-quota`, Deployment `quota-app` |
 
@@ -152,6 +164,8 @@ The ResourceQuota allows: `requests.cpu: 500m`, `requests.memory: 512Mi`.
 | | |
 |---|---|
 | **Points** | 5 |
+| **CNCF Domain** | Application Design and Build |
+| **CNCF Weight** | 20% |
 | **Namespace** | N/A (local task) |
 | **Resources** | Dockerfile at `./exam/course/7/image/Dockerfile` |
 
@@ -169,6 +183,8 @@ The ResourceQuota allows: `requests.cpu: 500m`, `requests.memory: 512Mi`.
 | | |
 |---|---|
 | **Points** | 6 |
+| **CNCF Domain** | Application Deployment |
+| **CNCF Weight** | 20% |
 | **Namespace** | `bulwark` |
 | **Resources** | Deployment `stable-app`, Service `app-svc` |
 
@@ -194,6 +210,8 @@ Create a **canary** Deployment named `canary-app` in namespace `bulwark` with:
 | | |
 |---|---|
 | **Points** | 4 |
+| **CNCF Domain** | Services and Networking |
+| **CNCF Weight** | 20% |
 | **Namespace** | `parapet` |
 | **Resources** | Deployment `backend`, Service `backend-svc` |
 
@@ -214,6 +232,8 @@ A Service `backend-svc` exists in namespace `parapet` but has no endpoints — t
 | | |
 |---|---|
 | **Points** | 5 |
+| **CNCF Domain** | Application Design and Build |
+| **CNCF Weight** | 20% |
 | **Namespace** | `stronghold` |
 | **Resources** | None (create from scratch) |
 
@@ -236,6 +256,8 @@ Create a CronJob named `cleanup-job` in namespace `stronghold`:
 | | |
 |---|---|
 | **Points** | 5 |
+| **CNCF Domain** | Application Environment, Configuration and Security |
+| **CNCF Weight** | 25% |
 | **Namespace** | `fortress` |
 | **Resources** | Deployment `secure-app` |
 
@@ -259,6 +281,8 @@ The Deployment must have running Pods after the update.
 | | |
 |---|---|
 | **Points** | 7 |
+| **CNCF Domain** | Application Environment, Configuration and Security |
+| **CNCF Weight** | 25% |
 | **Namespace** | `bastion` |
 | **Resources** | Deployment `pod-reader`, ServiceAccount `pod-reader-sa` |
 
@@ -285,6 +309,8 @@ Fix this by:
 | | |
 |---|---|
 | **Points** | 5 |
+| **CNCF Domain** | Application Deployment |
+| **CNCF Weight** | 20% |
 | **Namespace** | `citadel` |
 | **Resources** | Deployment `web-server` |
 
@@ -305,6 +331,8 @@ Save the rollout history output to `./exam/course/13/rollout-history.txt`.
 | | |
 |---|---|
 | **Points** | 4 |
+| **CNCF Domain** | Application Observability and Maintenance |
+| **CNCF Weight** | 15% |
 | **Namespace** | `rampart` |
 | **Resources** | Manifest at `./exam/course/14/broken-deploy.yaml` |
 
@@ -331,6 +359,8 @@ Fix the manifest:
 | | |
 |---|---|
 | **Points** | 5 |
+| **CNCF Domain** | Application Observability and Maintenance |
+| **CNCF Weight** | 15% |
 | **Namespace** | `tower` |
 | **Resources** | Deployment `health-app` |
 
@@ -351,6 +381,8 @@ Save the root cause description to `./exam/course/15/root-cause.txt`.
 | | |
 |---|---|
 | **Points** | 5 |
+| **CNCF Domain** | Application Environment, Configuration and Security |
+| **CNCF Weight** | 25% |
 | **Namespace** | `gate` |
 | **Resources** | None (create from scratch) |
 
@@ -371,6 +403,8 @@ Save the root cause description to `./exam/course/15/root-cause.txt`.
 | | |
 |---|---|
 | **Points** | 4 |
+| **CNCF Domain** | Services and Networking |
+| **CNCF Weight** | 20% |
 | **Namespace** | `gate` |
 | **Resources** | Deployment `backend-app` |
 
@@ -393,6 +427,8 @@ Verify the Service has endpoints.
 | | |
 |---|---|
 | **Points** | 5 |
+| **CNCF Domain** | Application Design and Build |
+| **CNCF Weight** | 20% |
 | **Namespace** | `bulwark` |
 | **Resources** | None (create from scratch) |
 
@@ -413,6 +449,8 @@ Create a Job named `batch-processor` in namespace `bulwark`:
 | | |
 |---|---|
 | **Points** | 5 |
+| **CNCF Domain** | Application Deployment |
+| **CNCF Weight** | 20% |
 | **Namespace** | `parapet` |
 | **Resources** | Deployment `rolling-app` |
 
@@ -434,6 +472,8 @@ This ensures zero-downtime deployments. The Deployment must have running Pods af
 | | |
 |---|---|
 | **Points** | 5 |
+| **CNCF Domain** | Application Design and Build |
+| **CNCF Weight** | 20% |
 | **Namespace** | `stronghold` |
 | **Resources** | Template at `./exam/course/20/sidecar-pod.yaml` |
 


### PR DESCRIPTION
## Summary

- Adds `**CNCF Domain**` + `**CNCF Weight**` metadata rows to all 20 questions in `exams/ckad-simulation10/questions.md` (Dojo Oni 👹)
- Mapping follows the CKAD 2026 curriculum (Design 20% / Deployment 20% / Env+Config+Security 25% / Observability 15% / Networking 20%)
- Confirms Oni's "exam-realistic, debug-focused" profile

## Distribution (by points / 102)

| Domain | Questions | Points | Share | Curriculum target |
|---|---|---|---|---|
| Application Design and Build | Q7, Q10, Q18, Q20 | 20 | 19.6% | 20% |
| Application Deployment | Q8, Q13, Q19 | 16 | 15.7% | 20% |
| Env, Config and Security | Q1, Q5, Q6, Q11, Q12, Q16 | 32 | 31.4% | 25% |
| Observability and Maintenance | Q14, Q15 | 9 | 8.8% | 15% |
| Services and Networking | Q2, Q3, Q4, Q9, Q17 | 25 | 24.5% | 20% |

Slight Config surplus + Observability deficit reflect Oni's debug/fix theme (RBAC, Quota, Secrets fixes) — coherent with its declared focus.

## Test plan

- [x] `grep -c "CNCF Domain"` returns 20
- [x] `grep -c "CNCF Weight"` returns 20
- [x] pre-commit hooks pass (markdownlint, codespell, commitizen)
- [x] diff is +40/-0 (insertions only)
- [ ] Web UI rendering will be wired in a later PR once all dojos are mapped (Amaterasu remaining)

🤖 Generated with [Claude Code](https://claude.com/claude-code)