### PR TITLE
feat: add CNCF domain mapping to dojo Amaterasu

### DIFF
--- a/exams/ckad-simulation11/questions.md
+++ b/exams/ckad-simulation11/questions.md
@@ -11,6 +11,8 @@
 |                     |                                          |
 | ------------------- | ---------------------------------------- |
 | **Points**    | 6                                        |
+| **CNCF Domain** | Application Design and Build |
+| **CNCF Weight** | 20% |
 | **Namespace** | -                                        |
 | **Resources** | Container image `solar-app:1.0`          |
 | **Files**     | `./exam/course/1/image/Dockerfile`, `./exam/course/1/image/index.html` |
@@ -33,6 +35,8 @@ Your tasks:
 |                     |                             |
 | ------------------- | --------------------------- |
 | **Points**    | 4                           |
+| **CNCF Domain** | Application Design and Build |
+| **CNCF Weight** | 20% |
 | **Namespace** | `solar`                   |
 | **Resources** | Deployment `frontend-app` |
 
@@ -56,6 +60,8 @@ Create a Deployment named **`frontend-app`** in namespace `solar` with:
 |                     |                                  |
 | ------------------- | -------------------------------- |
 | **Points**    | 6                                |
+| **CNCF Domain** | Application Design and Build |
+| **CNCF Weight** | 20% |
 | **Namespace** | `corona`                       |
 | **Resources** | Pod `web-with-sidecar`         |
 
@@ -83,6 +89,8 @@ Create a Pod named **`web-with-sidecar`** in namespace `corona` with a main cont
 |                     |                                               |
 | ------------------- | --------------------------------------------- |
 | **Points**    | 6                                             |
+| **CNCF Domain** | Application Design and Build |
+| **CNCF Weight** | 20% |
 | **Namespace** | `aurora`                                    |
 | **Resources** | PVC `app-data-pvc`, Pod `data-pod`, PV `app-data-pv` |
 
@@ -109,6 +117,8 @@ Your tasks:
 |                     |                                                                  |
 | ------------------- | ---------------------------------------------------------------- |
 | **Points**    | 8                                                                |
+| **CNCF Domain** | Application Deployment |
+| **CNCF Weight** | 20% |
 | **Namespace** | `flare`                                                        |
 | **Resources** | Deployment `app-blue`, Deployment `app-green`, Service `webapp-svc` |
 
@@ -138,6 +148,8 @@ Implement a **Blue/Green deployment** by:
 |                     |                          |
 | ------------------- | ------------------------ |
 | **Points**    | 6                        |
+| **CNCF Domain** | Application Deployment |
+| **CNCF Weight** | 20% |
 | **Namespace** | `dawn`                 |
 | **Resources** | Deployment `api-app`   |
 
@@ -162,6 +174,8 @@ Your tasks:
 |                     |                                                      |
 | ------------------- | ---------------------------------------------------- |
 | **Points**    | 6                                                    |
+| **CNCF Domain** | Application Deployment |
+| **CNCF Weight** | 20% |
 | **Namespace** | `zenith`                                           |
 | **Resources** | Deployment `prod-web-app`, Service `prod-web-svc`  |
 | **Files**     | `./exam/course/7/deployment.yaml`, `./exam/course/7/service.yaml` |
@@ -188,6 +202,8 @@ Your tasks:
 |                     |                                    |
 | ------------------- | ---------------------------------- |
 | **Points**    | 4                                  |
+| **CNCF Domain** | Application Deployment |
+| **CNCF Weight** | 20% |
 | **Namespace** | `radiance`                       |
 | **Resources** | Helm release `web-release`       |
 
@@ -210,6 +226,8 @@ Your tasks:
 |                     |                            |
 | ------------------- | -------------------------- |
 | **Points**    | 4                          |
+| **CNCF Domain** | Application Observability and Maintenance |
+| **CNCF Weight** | 15% |
 | **Namespace** | `eclipse`                |
 | **Resources** | Deployment `slow-app`    |
 
@@ -235,6 +253,8 @@ Ensure the Deployment rolls out successfully.
 |                     |                                         |
 | ------------------- | --------------------------------------- |
 | **Points**    | 6                                       |
+| **CNCF Domain** | Application Observability and Maintenance |
+| **CNCF Weight** | 15% |
 | **Namespace** | `solar`                               |
 | **Resources** | Pod `stuck-pod`                       |
 | **Files to create** | `./exam/course/10/pending-reason.txt` |
@@ -256,6 +276,8 @@ Your tasks:
 |                     |                                          |
 | ------------------- | ---------------------------------------- |
 | **Points**    | 4                                        |
+| **CNCF Domain** | Application Observability and Maintenance |
+| **CNCF Weight** | 15% |
 | **Namespace** | `corona`                               |
 | **Resources** | Pod `multi-logger`                     |
 | **Files to create** | `./exam/course/11/sidecar-logs.txt`    |
@@ -278,6 +300,8 @@ Your tasks:
 |                     |                                        |
 | ------------------- | -------------------------------------- |
 | **Points**    | 6                                      |
+| **CNCF Domain** | Application Environment, Configuration and Security |
+| **CNCF Weight** | 25% |
 | **Namespace** | `aurora`                             |
 | **Resources** | CRD `backups.ckad.example.com`, Backup `daily-backup` |
 | **Files to create** | `./exam/course/12/crd-group.txt`     |
@@ -306,6 +330,8 @@ Your tasks:
 |                     |                                      |
 | ------------------- | ------------------------------------ |
 | **Points**    | 4                                    |
+| **CNCF Domain** | Application Environment, Configuration and Security |
+| **CNCF Weight** | 25% |
 | **Namespace** | `flare`                            |
 | **Resources** | Secret `web-tls`                   |
 | **Files**     | `./exam/course/13/tls.crt`, `./exam/course/13/tls.key` |
@@ -325,6 +351,8 @@ Create a **TLS Secret** named **`web-tls`** in namespace `flare` using these fil
 |                     |                              |
 | ------------------- | ---------------------------- |
 | **Points**    | 4                            |
+| **CNCF Domain** | Application Environment, Configuration and Security |
+| **CNCF Weight** | 25% |
 | **Namespace** | `dawn`                     |
 | **Resources** | Deployment `hardened-app`  |
 
@@ -349,6 +377,8 @@ Ensure the Deployment rolls out successfully after the changes.
 |                     |                                                                              |
 | ------------------- | ---------------------------------------------------------------------------- |
 | **Points**    | 6                                                                            |
+| **CNCF Domain** | Application Environment, Configuration and Security |
+| **CNCF Weight** | 25% |
 | **Namespace** | `zenith`                                                                   |
 | **Resources** | ServiceAccount `deploy-sa`, Role `deploy-role`, RoleBinding `deploy-rb`    |
 | **Files to create** | `./exam/course/15/auth-check.txt`                                          |
@@ -372,6 +402,8 @@ Create RBAC resources in namespace `zenith` to allow a ServiceAccount to manage 
 |                     |                                     |
 | ------------------- | ----------------------------------- |
 | **Points**    | 4                                   |
+| **CNCF Domain** | Application Environment, Configuration and Security |
+| **CNCF Weight** | 25% |
 | **Namespace** | `eclipse`                         |
 | **Resources** | ConfigMap `app-config`, Pod `config-pod` |
 | **Files**     | `./exam/course/16/app.env`        |
@@ -397,6 +429,8 @@ Your tasks:
 |                     |                                |
 | ------------------- | ------------------------------ |
 | **Points**    | 4                              |
+| **CNCF Domain** | Application Environment, Configuration and Security |
+| **CNCF Weight** | 25% |
 | **Namespace** | `radiance`                   |
 | **Resources** | Secret `registry-creds`      |
 
@@ -417,6 +451,8 @@ Create a **docker-registry** Secret named **`registry-creds`** in namespace `rad
 |                     |                                   |
 | ------------------- | --------------------------------- |
 | **Points**    | 6                                 |
+| **CNCF Domain** | Services and Networking |
+| **CNCF Weight** | 20% |
 | **Namespace** | `sunbeam`                       |
 | **Resources** | NetworkPolicy `api-allow`       |
 
@@ -441,6 +477,8 @@ Create a NetworkPolicy named **`api-allow`** in namespace `sunbeam` that:
 |                     |                                                          |
 | ------------------- | -------------------------------------------------------- |
 | **Points**    | 6                                                        |
+| **CNCF Domain** | Services and Networking |
+| **CNCF Weight** | 20% |
 | **Namespace** | `solstice`                                             |
 | **Resources** | Ingress `secure-ingress`, Secret `secure-tls`, Service `secure-svc` |
 
@@ -465,6 +503,8 @@ Create an Ingress named **`secure-ingress`** in namespace `solstice` that:
 |                     |                                          |
 | ------------------- | ---------------------------------------- |
 | **Points**    | 4                                        |
+| **CNCF Domain** | Services and Networking |
+| **CNCF Weight** | 20% |
 | **Namespace** | `sunbeam`                              |
 | **Resources** | Deployment `dns-app`, Service `dns-svc` |
 | **Files to create** | `./exam/course/20/dns-output.txt`      |


### PR DESCRIPTION
## Summary

- Adds `**CNCF Domain**` + `**CNCF Weight**` metadata rows to all 20 questions in `exams/ckad-simulation11/questions.md` (Dojo Amaterasu ☀️)
- Mapping follows the CKAD v1.35 curriculum (Design 20% / Deployment 20% / Observability 15% / Env+Config+Security 25% / Networking 20%)
- **Milestone**: completes the CNCF mapping for all 11 public dojos (218 questions) → web UI surfacing of CNCF coverage is now unblocked

## Distribution (by points / 104)

| Domain | Questions | Points | Share | Curriculum target | Δ |
|---|---|---|---|---|---|
| Application Design and Build | Q1, Q2, Q3, Q4 | 22 | 21.2% | 20% | +1.2pp |
| Application Deployment | Q5, Q6, Q7, Q8 | 24 | 23.1% | 20% | +3.1pp |
| Application Observability and Maintenance | Q9, Q10, Q11 | 14 | 13.5% | 15% | -1.5pp |
| Application Environment, Configuration and Security | Q12–Q17 | 28 | 26.9% | 25% | +1.9pp |
| Services and Networking | Q18, Q19, Q20 | 16 | 15.4% | 20% | -4.6pp |

Very close to the official curriculum weights (max deviation -4.6pp, well within the ±15pp CA-002 tolerance). Amaterasu was designed to fill curriculum gaps — Kustomize, Blue/Green, Startup Probe, CRDs, TLS/docker-registry Secrets, NetworkPolicy ipBlock, Ingress TLS termination, multi-container log selection, ConfigMap from env-file.

## Naming convention

Uses `Application Environment, Configuration and Security` (official CNCF v1.35 wording, matching sim10 / Oni). Note: sim6–9 still use `Configuration & Security` (with ampersand) — harmonization is a separate cleanup before UI wiring.

## Test plan

- [x] `grep -c "CNCF Domain"` returns 20
- [x] `grep -c "CNCF Weight"` returns 20
- [x] pre-commit hooks pass (markdownlint, codespell, commitizen, secrets detection)
- [x] Diff is +40/-0 (insertions only, no question content modified)
- [x] All 11 public dojos now mapped (sim1–11 ✅)

🤖 Generated with [Claude Code](https://claude.com/claude-code)