### PR TITLE
fix(setup): resolve zero-padded question numbers in template copy

### DIFF
--- a/scripts/lib/setup-functions.sh
+++ b/scripts/lib/setup-functions.sh
@@ -7,6 +7,18 @@ SCRIPT_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_LIB_DIR/common.sh"
 
 # ============================================================================
+# HELPERS
+# ============================================================================
+
+# Extract the question number from a template file or directory name
+# Strips the "q" prefix and any zero padding, so that q07-image and q7-image
+# both resolve to the same exam/course/7 target directory
+# Usage: extract_question_number <template_basename>
+extract_question_number() {
+	echo "$1" | sed 's/^q0*\([0-9]*\)-.*/\1/'
+}
+
+# ============================================================================
 # SETUP FUNCTIONS
 # ============================================================================
 
@@ -93,7 +105,7 @@ setup_directories() {
 		for image_dir in "$templates_dir"/q*-image/; do
 			if [ -d "$image_dir" ]; then
 				local q_num
-				q_num=$(basename "$image_dir" | sed 's/q\([0-9]*\)-.*/\1/')
+				q_num=$(extract_question_number "$(basename "$image_dir")")
 				mkdir -p "$EXAM_DIR/$q_num/image"
 			fi
 		done
@@ -123,7 +135,7 @@ setup_templates() {
 			filename=$(basename "$template")
 			# Extract question number (e.g., q09-pod.yaml -> 9, q15-web-moon.html -> 15)
 			local q_num
-			q_num=$(echo "$filename" | sed 's/q0*\([0-9]*\)-.*/\1/')
+			q_num=$(extract_question_number "$filename")
 			# Extract target filename (e.g., q09-pod.yaml -> pod.yaml, q15-web-moon.html -> web-moon.html)
 			local target_name
 			target_name=$(echo "$filename" | sed 's/q[0-9]*-//')
@@ -163,12 +175,15 @@ setup_templates() {
 			dirname=$(basename "$image_dir")
 			# Extract question number
 			local q_num
-			q_num=$(echo "$dirname" | sed 's/q0*\([0-9]*\)-.*/\1/')
+			q_num=$(extract_question_number "$dirname")
 
 			if [ -d "$EXAM_DIR/$q_num/image" ]; then
 				cp -r "$image_dir"* "$EXAM_DIR/$q_num/image/"
 				print_success "Q$q_num: image files (Dockerfile, etc.)"
 				((++copied))
+			else
+				print_fail "Q$q_num: no target directory $EXAM_DIR/$q_num/image for template $dirname"
+				((++errors))
 			fi
 		fi
 	done

--- a/tests/test-setup-functions.sh
+++ b/tests/test-setup-functions.sh
@@ -106,6 +106,40 @@ assert_not_empty "$HELM_NAMESPACE" "HELM_NAMESPACE should be set for simulation2
 load_exam "ckad-simulation3"
 assert_not_empty "$HELM_NAMESPACE" "HELM_NAMESPACE should be set for simulation3"
 
+# ----------------------------------------------------------------------------
+# Test: Question number extraction (regression - issue #103)
+# ----------------------------------------------------------------------------
+test_case "Question numbers are extracted consistently from template names"
+
+assert_function_exists "extract_question_number" "extract_question_number function should exist"
+
+assert_equals "7" "$(extract_question_number "q07-image")" "Zero-padded image dir q07-image should yield 7"
+assert_equals "7" "$(extract_question_number "q07-pod.yaml")" "Zero-padded file q07-pod.yaml should yield 7"
+assert_equals "1" "$(extract_question_number "q1-image")" "Unpadded image dir q1-image should yield 1"
+assert_equals "12" "$(extract_question_number "q12-image")" "Two-digit image dir q12-image should yield 12"
+assert_equals "15" "$(extract_question_number "q15-web-moon.html")" "Multi-dash file name should yield 15"
+
+# ----------------------------------------------------------------------------
+# Test: Image templates are copied (regression - issue #103)
+# ----------------------------------------------------------------------------
+test_case "Image templates are copied for zero-padded question numbers"
+
+# simulation10 is the only exam with a zero-padded image template (q07-image)
+load_exam "ckad-simulation10" >/dev/null 2>&1
+
+TEST_EXAM_DIR=$(mktemp -d)
+SAVED_EXAM_DIR="$EXAM_DIR"
+EXAM_DIR="$TEST_EXAM_DIR"
+
+setup_directories >/dev/null 2>&1
+setup_templates >/dev/null 2>&1
+
+assert_file_exists "$TEST_EXAM_DIR/7/image/Dockerfile" "Q7 Dockerfile should land in exam/course/7/image"
+assert_true '[ ! -d "$TEST_EXAM_DIR/07" ]' "No zero-padded exam/course/07 directory should be created"
+
+EXAM_DIR="$SAVED_EXAM_DIR"
+rm -rf "$TEST_EXAM_DIR"
+
 # ============================================================================
 # SUMMARY
 # ============================================================================


### PR DESCRIPTION
Fixes #103

## Problem

`ckad-simulation10` question 7 asks the candidate to build an image from `./exam/course/7/image/`, but that directory was never populated: the `Dockerfile` and `index.html` templates were silently not copied during setup.

## Root cause

`setup_directories` and `setup_templates` extracted the question number from template names with two different `sed` expressions:

| Function | Expression | Result for `q07-image/` |
|---|---|---|
| `setup_directories` | `s/q\([0-9]*\)-.*/\1/` | `07` → creates `exam/course/07/image` |
| `setup_templates` | `s/q0*\([0-9]*\)-.*/\1/` | `7` → looks for `exam/course/7/image` |

The copy is guarded by `if [ -d "$EXAM_DIR/$q_num/image" ]`, so the test failed and the copy was skipped without any error or warning in the setup output.

`ckad-simulation10` was the only exam affected, being the only one whose image template directory uses a leading zero. Flat templates such as `q07-pod.yaml` were unaffected, since `setup_directories` creates `1..N` without padding.

## Fix

Both call sites now share a single helper:

```bash
extract_question_number() {
	echo "$1" | sed 's/^q0*\([0-9]*\)-.*/\1/'
}
```

This closes the whole class of bugs rather than the single affected template — renaming `q07-image/` to `q7-image/` would have fixed this occurrence while leaving the trap armed for the next simulation.

The image copy loop now also reports a failure and increments `errors` when the target directory is missing, instead of skipping silently.

## Verification

- `./tests/run-tests.sh` — 5/5 suites, 52/52 assertions pass
- `shellcheck --severity=warning scripts/*.sh scripts/lib/*.sh exams/*/scoring-functions.sh` — clean
- Regression tests added in `tests/test-setup-functions.sh`, written before the fix and confirmed red first. The second one runs the real `setup_directories` + `setup_templates` chain on `ckad-simulation10` in a temp directory, so it covers the full path rather than just the helper.
- Non-regression checked on all 7 exams carrying an image template (`q1-`, `q5-`, `q07-`, `q11-`, `q12-`, `q22-`): every Dockerfile lands in the expected directory, no spurious warning.

Question 7 of Dojo Oni is solvable end to end again.
