### PR TITLE
fix(sim1): Dockerfile path, docker manifest --insecure, helm status, values schema, ttyd port

### DIFF
--- a/exams/ckad-simulation1/questions.md
+++ b/exams/ckad-simulation1/questions.md
@@ -278,7 +278,7 @@ Create a **NetworkPolicy** named `allow-from-flame` in namespace `corona` that:
 |   **CNCF Domain**   | Application Design and Build         |
 |   **CNCF Weight**   | 20%                                  |
 | **Namespace**       | `inferno`                          |
-| **File to modify**  | `./exam/course/12/Dockerfile`      |
+| **File to modify**  | `./exam/course/12/image/Dockerfile`      |
 | **Image to create** | `localhost:5000/phoenix-app:2.0.0` |
 
 ### Task

--- a/exams/ckad-simulation1/scoring-functions.sh
+++ b/exams/ckad-simulation1/scoring-functions.sh
@@ -437,7 +437,7 @@ score_q12() {
 	echo "Question 12 | Docker Build with ARG"
 
 	# Check Dockerfile exists
-	local dockerfile="$EXAM_DIR/12/Dockerfile"
+	local dockerfile="$EXAM_DIR/12/image/Dockerfile"
 	check_criterion "Dockerfile exists" "$([ -f "$dockerfile" ] && echo true || echo false)" && ((score++))
 
 	if [ -f "$dockerfile" ]; then
@@ -460,7 +460,7 @@ score_q12() {
 	check_criterion "Image has version=2.0.0 label" "$([ "$label" = "2.0.0" ] && echo true || echo false)" && ((score++))
 
 	# Check pushed to registry (try to pull)
-	local pushed=$(docker manifest inspect localhost:5000/phoenix-app:2.0.0 2>/dev/null && echo true || echo false)
+	local pushed=$(docker manifest inspect --insecure localhost:5000/phoenix-app:2.0.0 > /dev/null 2>&1 && echo true || echo false)
 	check_criterion "Image pushed to localhost:5000" "$pushed" && ((score++))
 
 	echo "$score/$total"
@@ -481,11 +481,11 @@ score_q13() {
 	check_criterion "Values file exists" "$([ -f "$values_file" ] && echo true || echo false)" && ((score++))
 
 	# Check Helm release exists
-	local release_exists=$(helm list -n flare 2>/dev/null | grep -q "phoenix-api" && echo true || echo false)
+	local release_exists=$(helm status phoenix-api -n flare >/dev/null 2>&1 && echo true || echo false)
 	check_criterion "Helm release phoenix-api exists in flare" "$release_exists" && ((score++))
 
 	# Check release status
-	local status=$(helm list -n flare -o json 2>/dev/null | grep -o '"status":"[^"]*"' | head -1 | cut -d'"' -f4)
+	local status=$(helm status phoenix-api -n flare -o json 2>/dev/null | grep -o '"status":"[^"]*"' | head -1 | cut -d'"' -f4)
 	check_criterion "Release status is deployed" "$([ "$status" = "deployed" ] && echo true || echo false)" && ((score++))
 
 	# Check replicas (should be 3 from values file)

--- a/exams/ckad-simulation1/solutions.md
+++ b/exams/ckad-simulation1/solutions.md
@@ -2,7 +2,7 @@
 
 *「朱雀は灰から蘇る」 - Le phénix renaît de ses cendres*
 
-This document contains the solutions for all 21 questions in CKAD Simulation 2.
+This document contains the solutions for all 21 questions in CKAD Simulation 1.
 
 ---
 
@@ -361,8 +361,8 @@ EOF
 
 ```bash
 # Copy template
-mkdir -p ./exam/course/12
-cp ./templates/q12-image/* ./exam/course/12/
+mkdir -p ./exam/course/12/image
+cp ./templates/q12-image/* ./exam/course/12/image/
 
 # Modify Dockerfile
 cat <<EOF > ./exam/course/12/image/Dockerfile
@@ -379,7 +379,7 @@ CMD ["nginx", "-g", "daemon off;"]
 EOF
 
 # Build with custom ARG value
-cd ./exam/course/12
+cd ./exam/course/12/image
 sudo docker build --build-arg APP_VERSION=2.0.0 -t localhost:5000/phoenix-app:2.0.0 .
 
 # Push to registry

--- a/exams/ckad-simulation1/templates/q13-values.yaml
+++ b/exams/ckad-simulation1/templates/q13-values.yaml
@@ -8,7 +8,8 @@ image:
 
 service:
   type: ClusterIP
-  port: 8080
+  ports:
+    http: 8080
 
 resources:
   requests:

--- a/scripts/ckad-exam.sh
+++ b/scripts/ckad-exam.sh
@@ -59,7 +59,7 @@ show_help() {
 	echo "  --no-hints       Disable hints (remove Hint/Tip boxes)"
 	echo "  --skip-detection Skip existing exam resource detection"
 	echo "  --port PORT      Web interface port (default: $WEB_PORT)"
-	echo "  --terminal-port PORT  Terminal port (default: 7681)"
+	echo "  --terminal-port PORT  Terminal port (default: 7682)"
 	echo "  --browser NAME   Browser to use (firefox, chrome, chromium, brave, default)"
 	echo "                   Can also be set via CKAD_BROWSER env variable"
 	echo ""

--- a/web/server.py
+++ b/web/server.py
@@ -545,7 +545,7 @@ class ExamHandler(http.server.SimpleHTTPRequestHandler):
                 self.send_json({"enabled": False, "running": False, "port": 0, "url": None})
             else:
                 # Check if ttyd is running
-                ttyd_port = int(os.environ.get("TTYD_PORT", "7681"))
+                ttyd_port = int(os.environ.get("TTYD_PORT", "7682"))
                 ttyd_running = self.check_ttyd_status(ttyd_port)
                 self.send_json(
                     {


### PR DESCRIPTION
## Summary

Focused bug fixes for `ckad-simulation1` and ttyd port alignment. Six files changed, nothing else.

## Changes

### `exams/ckad-simulation1/questions.md`
- **Q12**: Correct Dockerfile path from `./exam/course/12/Dockerfile` → `./exam/course/12/image/Dockerfile` (matches what `setup-functions.sh` actually copies into `$EXAM_DIR/$q_num/image/`)

### `exams/ckad-simulation1/scoring-functions.sh`
- **Q12**: Add `--insecure` flag to `docker manifest inspect` — local registry is plain HTTP, not HTTPS
- **Q12**: Redirect `docker manifest inspect` JSON stdout to `/dev/null 2>&1` so the scoring variable capture is not polluted
- **Q13**: Replace `helm list -n flare | grep -o` with `helm status phoenix-api -n flare` — the old form graded whichever release happened to be first in the namespace

### `exams/ckad-simulation1/solutions.md`
- Title typo: "Simulation 2" → "Simulation 1"
- **Q12**: Align Dockerfile path with the fix above

### `exams/ckad-simulation1/templates/q13-values.yaml`
- `service.port: 8080` → `service.ports.http: 8080` (current bitnami/nginx Helm chart schema)

### `web/server.py`
- Default `TTYD_PORT` fallback: `"7681"` → `"7682"` (aligns with `common.sh` default)

### `scripts/ckad-exam.sh`
- Help text: `Terminal port (default: 7681)` → `Terminal port (default: 7682)`

## Testing

End-to-end validated on a local `kind` cluster: `ckad-simulation1` scores **112/112 (100%)** with these fixes applied.