### PR TITLE
fix(css): add missing .criterion-text style rules

### DIFF
--- a/web/css/style.css
+++ b/web/css/style.css
@@ -1174,7 +1174,8 @@ html, body {
     font-weight: 600;
 }
 
-.criterion-description {
+.criterion-description,
+.criterion-text {
     flex: 1;
     color: var(--text-secondary);
 }
@@ -1183,7 +1184,8 @@ html, body {
     color: var(--accent-success);
 }
 
-.criterion-pass .criterion-description {
+.criterion-pass .criterion-description,
+.criterion-pass .criterion-text {
     color: var(--text-primary);
 }
 
@@ -1191,7 +1193,8 @@ html, body {
     color: var(--accent-danger);
 }
 
-.criterion-fail .criterion-description {
+.criterion-fail .criterion-description,
+.criterion-fail .criterion-text {
     color: var(--text-secondary);
 }
 


### PR DESCRIPTION
## Problem

`app.js` line 758 renders each score criterion as:
```html
<span class="criterion-text">${c.description}</span>
```

But `style.css` has no rule for `.criterion-text` — only `.criterion-description`. The span is completely unstyled: wrong colour, no flex layout, and pass/fail colour overrides do not apply.

## Fix

Add `.criterion-text` as a sibling to `.criterion-description` in all three relevant rules:

```css
/* base */
.criterion-description,
.criterion-text { flex: 1; color: var(--text-secondary); }

/* pass override */
.criterion-pass .criterion-description,
.criterion-pass .criterion-text { color: var(--text-primary); }

/* fail override */
.criterion-fail .criterion-description,
.criterion-fail .criterion-text { color: var(--text-secondary); }
```

The compound selectors (`.criterion-pass .criterion-text`) ensure the colour overrides only apply inside a pass/fail row, avoiding the global-selector problem that a plain `.criterion-text { … }` rule would introduce.

## Testing

- `uvx ruff check web/ ckad_dojo.py` → All checks passed (no Python changed)
- Only `web/css/style.css` changed — 1 file, 3 extra selector lines