### PR TITLE
fix(ci): resolve pre-commit failures from simulations 12-20 merge

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,8 @@ repos:
       - id: check-merge-conflict
       - id: check-yaml
         files: \.(yml|yaml)$
-        exclude: (^\.venv/)
+        # Helm chart templates contain Go templating and are not valid YAML
+        exclude: (^\.venv/|-chart/templates/)
         args: [--allow-multiple-documents]
       - id: check-toml
       - id: check-json
@@ -69,7 +70,8 @@ repos:
     hooks:
       - id: yamllint
         files: \.(yml|yaml)$
-        exclude: (^\.venv/)
+        # Helm chart templates contain Go templating and are not valid YAML
+        exclude: (^\.venv/|-chart/templates/)
 
   # =============================================================================
   # Python

--- a/exams/ckad-simulation1/scoring-functions.sh
+++ b/exams/ckad-simulation1/scoring-functions.sh
@@ -460,7 +460,7 @@ score_q12() {
 	check_criterion "Image has version=2.0.0 label" "$([ "$label" = "2.0.0" ] && echo true || echo false)" && ((score++))
 
 	# Check pushed to registry (try to pull)
-	local pushed=$(docker manifest inspect --insecure localhost:5000/phoenix-app:2.0.0 > /dev/null 2>&1 && echo true || echo false)
+	local pushed=$(docker manifest inspect --insecure localhost:5000/phoenix-app:2.0.0 >/dev/null 2>&1 && echo true || echo false)
 	check_criterion "Image pushed to localhost:5000" "$pushed" && ((score++))
 
 	echo "$score/$total"

--- a/exams/ckad-simulation12/post-setup.sh
+++ b/exams/ckad-simulation12/post-setup.sh
@@ -2,24 +2,24 @@
 # CKAD Simulation 12 - Post Setup
 
 function exam_post_setup() {
-  echo "Running post-setup for Simulation 12..."
-  
-  echo "Upgrading Helm chart api-release with a bad image to create failure scenario..."
-  helm upgrade api-release bitnami/nginx --set image.tag="nonexistent-tag-12345" -n nebula --reuse-values --wait=false
+	echo "Running post-setup for Simulation 12..."
 
-  echo "Triggering rollout deployment update for Q7..."
-  kubectl set image deployment/critical-processor app=nginx:1.25 -n nightfall
+	echo "Upgrading Helm chart api-release with a bad image to create failure scenario..."
+	helm upgrade api-release bitnami/nginx --set image.tag="nonexistent-tag-12345" -n nebula --reuse-values --wait=false
 
-  # === Auto-generated starter files ===
-  local BASE_DIR="./exam/course"
-  mkdir -p "$BASE_DIR/12/q1"
-  cat << 'EOF_FILE' > "$BASE_DIR/12/q1/Dockerfile"
+	echo "Triggering rollout deployment update for Q7..."
+	kubectl set image deployment/critical-processor app=nginx:1.25 -n nightfall
+
+	# === Auto-generated starter files ===
+	local BASE_DIR="./exam/course"
+	mkdir -p "$BASE_DIR/12/q1"
+	cat <<'EOF_FILE' >"$BASE_DIR/12/q1/Dockerfile"
 # /opt/course/12/q1/Dockerfile
 FROM golang:1.20-alpine
 # TODO: Complete this Dockerfile per the task instructions
 EOF_FILE
 
-  cat << 'EOF_FILE' > "$BASE_DIR/12/q1/main.go"
+	cat <<'EOF_FILE' >"$BASE_DIR/12/q1/main.go"
 package main
 import "fmt"
 func main() {
@@ -27,8 +27,8 @@ func main() {
 }
 EOF_FILE
 
-  mkdir -p "$BASE_DIR/12/q8"
-  cat << 'EOF_FILE' > "$BASE_DIR/12/q8/deployment.yaml"
+	mkdir -p "$BASE_DIR/12/q8"
+	cat <<'EOF_FILE' >"$BASE_DIR/12/q8/deployment.yaml"
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -49,14 +49,14 @@ spec:
         image: nginx:1.24
 EOF_FILE
 
-  cat << 'EOF_FILE' > "$BASE_DIR/12/q8/kustomization.yaml"
+	cat <<'EOF_FILE' >"$BASE_DIR/12/q8/kustomization.yaml"
 resources:
   - deployment.yaml
 EOF_FILE
 
-  mkdir -p "$BASE_DIR/12/q10"
-  
-  mkdir -p "$BASE_DIR/12/q20"
-  
-  return 0
+	mkdir -p "$BASE_DIR/12/q10"
+
+	mkdir -p "$BASE_DIR/12/q20"
+
+	return 0
 }

--- a/exams/ckad-simulation12/questions.md
+++ b/exams/ckad-simulation12/questions.md
@@ -31,6 +31,7 @@ In the `lunar` namespace, you are tasked with creating a multi-stage Dockerfile.
 A stub Dockerfile has been provided at `./exam/course/12/q1/Dockerfile` and a simple main.go program at `./exam/course/12/q1/main.go`.
 
 Update the Dockerfile to have two stages:
+
 1. The first stage should use `golang:1.20-alpine` as the base image. Name it `builder`.
    - Copy `main.go` into `/app/`.
    - Build it with `go build -o /app/server /app/main.go`.
@@ -75,6 +76,7 @@ Add an init container named `wait-for-service` using the `busybox:1.36` image. T
 ### Task
 
 In the `twilight` namespace, create a CronJob named `nightly-backup`.
+
 - Schedule: every 10 minutes (`*/10 * * * *`).
 - Container image: `busybox:1.36`.
 - Command: `sh -c 'sleep 30'`.
@@ -135,6 +137,7 @@ Roll back the `api-release` release to its previous revision (revision 1).
 ### Task
 
 Create a Deployment named `slow-start-app` in the `shadow` namespace.
+
 - Replicas: 3
 - Image: `nginx:1.24`
 - To ensure no downtime during updates for this application that takes time to initialize, set `minReadySeconds` to `20`.
@@ -253,6 +256,7 @@ Use an `emptyDir` volume to share the `/var/log` directory between the two conta
 In the `crescent` namespace, a Secret named `db-creds` and a ConfigMap named `app-config` exist.
 Create a Pod named `combined-app` using the `nginx:alpine` image.
 Use a single `projected` volume mounted at `/opt/config` to expose:
+
 1. The `db-creds` Secret.
 2. The `app-config` ConfigMap.
 
@@ -290,6 +294,7 @@ Configure the ConfigMap to be immutable to prevent accidental changes.
 
 Create a Pod named `secure-pod` in the `eclipse` namespace using the `nginx:alpine` image.
 Apply the following security constraints:
+
 1. The pod must run as user ID `1000`.
 2. The container must NOT allow privilege escalation (`allowPrivilegeEscalation: false`).
 3. The container must have a read-only root filesystem.
@@ -329,6 +334,7 @@ A Pod named `token-reader` in the same namespace mounts this secret. No changes 
 
 Create a ResourceQuota named `compute-quota` in the `nightfall` namespace.
 Enforce the following limits:
+
 - Hard limit of `4` Pods.
 - Hard limit of `2` CPU requests.
 - Hard limit of `4Gi` Memory limits.
@@ -368,6 +374,7 @@ DENY all EGRESS traffic, except for traffic to DNS (UDP port 53).
 
 Create an Ingress named `star-ingress` in the `starlight` namespace.
 Route traffic based on paths:
+
 - Requests to `/api(/|$)(.*)` should route to a Service named `api-svc` on port 8080 (Prefix match).
 - Requests to `/web(/|$)(.*)` should route to a Service named `web-svc` on port 80 (Prefix match).
 Set the ingress class to `nginx`.

--- a/exams/ckad-simulation12/scoring-functions.sh
+++ b/exams/ckad-simulation12/scoring-functions.sh
@@ -5,476 +5,476 @@ EXAM_DIR="./exam/course/12"
 source "$SCRIPT_DIR/../../scripts/lib/common.sh" 2>/dev/null || true
 
 score_q1() {
-  local score=0
-  local max_points=6
-  local details=""
-  
-  if [ -f "$EXAM_DIR/q1/Dockerfile" ]; then
-    if grep -q -E "FROM golang:1.20-alpine AS builder|FROM golang:1.20-alpine as builder" "$EXAM_DIR/q1/Dockerfile"; then
-      ((score+=2))
-      details+="Builder stage defined. "
-    fi
-    if grep -q "FROM alpine:3.18" "$EXAM_DIR/q1/Dockerfile"; then
-      ((score+=2))
-      details+="Alpine stage defined. "
-    fi
-    if grep -q "COPY --from=builder" "$EXAM_DIR/q1/Dockerfile"; then
-      ((score+=2))
-      details+="Binary copied from builder. "
-    fi
-  else
-    details+="Dockerfile not found. "
-  fi
-  
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+	local score=0
+	local max_points=6
+	local details=""
+
+	if [ -f "$EXAM_DIR/q1/Dockerfile" ]; then
+		if grep -q -E "FROM golang:1.20-alpine AS builder|FROM golang:1.20-alpine as builder" "$EXAM_DIR/q1/Dockerfile"; then
+			((score += 2))
+			details+="Builder stage defined. "
+		fi
+		if grep -q "FROM alpine:3.18" "$EXAM_DIR/q1/Dockerfile"; then
+			((score += 2))
+			details+="Alpine stage defined. "
+		fi
+		if grep -q "COPY --from=builder" "$EXAM_DIR/q1/Dockerfile"; then
+			((score += 2))
+			details+="Binary copied from builder. "
+		fi
+	else
+		details+="Dockerfile not found. "
+	fi
+
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q2() {
-  local score=0
-  local max_points=5
-  local details=""
-  
-  if resource_exists "pod" "data-processor" "crescent"; then
-    ((score+=1))
-    
-    local init_img=$(kubectl get pod data-processor -n crescent -o jsonpath='{.spec.initContainers[0].image}' 2>/dev/null)
-    if [ "$init_img" == "busybox:1.36" ]; then
-      ((score+=2))
-      details+="Init container image correct. "
-    else
-      details+="Init container image incorrect. "
-    fi
-    
-    local main_img=$(kubectl get pod data-processor -n crescent -o jsonpath='{.spec.containers[0].image}' 2>/dev/null)
-    if [ "$main_img" == "nginx:alpine" ]; then
-      ((score+=2))
-      details+="Main container image correct. "
-    fi
-  else
-    details+="Pod data-processor not found in crescent namespace. "
-  fi
-  
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+	local score=0
+	local max_points=5
+	local details=""
+
+	if resource_exists "pod" "data-processor" "crescent"; then
+		((score += 1))
+
+		local init_img=$(kubectl get pod data-processor -n crescent -o jsonpath='{.spec.initContainers[0].image}' 2>/dev/null)
+		if [ "$init_img" == "busybox:1.36" ]; then
+			((score += 2))
+			details+="Init container image correct. "
+		else
+			details+="Init container image incorrect. "
+		fi
+
+		local main_img=$(kubectl get pod data-processor -n crescent -o jsonpath='{.spec.containers[0].image}' 2>/dev/null)
+		if [ "$main_img" == "nginx:alpine" ]; then
+			((score += 2))
+			details+="Main container image correct. "
+		fi
+	else
+		details+="Pod data-processor not found in crescent namespace. "
+	fi
+
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q3() {
-  local score=0
-  local max_points=5
-  local details=""
-  
-  if resource_exists "cronjob" "nightly-backup" "twilight"; then
-    ((score+=2))
-    
-    local conc=$(kubectl get cronjob nightly-backup -n twilight -o jsonpath='{.spec.concurrencyPolicy}' 2>/dev/null)
-    if [ "$conc" == "Forbid" ]; then
-      ((score+=3))
-      details+="ConcurrencyPolicy is Forbid. "
-    else
-      details+="ConcurrencyPolicy is not Forbid ($conc). "
-    fi
-  else
-    details+="Cronjob nightly-backup not found in twilight namespace. "
-  fi
-  
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+	local score=0
+	local max_points=5
+	local details=""
+
+	if resource_exists "cronjob" "nightly-backup" "twilight"; then
+		((score += 2))
+
+		local conc=$(kubectl get cronjob nightly-backup -n twilight -o jsonpath='{.spec.concurrencyPolicy}' 2>/dev/null)
+		if [ "$conc" == "Forbid" ]; then
+			((score += 3))
+			details+="ConcurrencyPolicy is Forbid. "
+		else
+			details+="ConcurrencyPolicy is not Forbid ($conc). "
+		fi
+	else
+		details+="Cronjob nightly-backup not found in twilight namespace. "
+	fi
+
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q4() {
-  local score=0
-  local max_points=6
-  local details=""
-  
-  if resource_exists "pod" "legacy-app" "eclipse"; then
-    ((score+=2))
-    
-    local conts=$(kubectl get pod legacy-app -n eclipse -o jsonpath='{range .spec.containers[*]}{.name}{" "}{.image}{"\n"}{end}' 2>/dev/null)
-    if echo "$conts" | grep -q "backend nginx:1.25"; then
-      ((score+=2))
-      details+="Backend container correct. "
-    fi
-    if echo "$conts" | grep -q "proxy haproxy:2.8-alpine"; then
-      ((score+=2))
-      details+="Proxy container correct. "
-    fi
-  else
-    details+="Pod legacy-app not found in eclipse namespace. "
-  fi
-  
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+	local score=0
+	local max_points=6
+	local details=""
+
+	if resource_exists "pod" "legacy-app" "eclipse"; then
+		((score += 2))
+
+		local conts=$(kubectl get pod legacy-app -n eclipse -o jsonpath='{range .spec.containers[*]}{.name}{" "}{.image}{"\n"}{end}' 2>/dev/null)
+		if echo "$conts" | grep -q "backend nginx:1.25"; then
+			((score += 2))
+			details+="Backend container correct. "
+		fi
+		if echo "$conts" | grep -q "proxy haproxy:2.8-alpine"; then
+			((score += 2))
+			details+="Proxy container correct. "
+		fi
+	else
+		details+="Pod legacy-app not found in eclipse namespace. "
+	fi
+
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q5() {
-  local score=0
-  local max_points=5
-  local details=""
-  
-  local rev=$(helm history api-release -n nebula -o json 2>/dev/null | jq -r '.[-1].description' 2>/dev/null)
-  if [[ "$rev" == *"Rollback to 1"* ]]; then
-    ((score+=5))
-    details+="Release rolled back to 1. "
-  else
-    details+="Release not rolled back to 1. "
-  fi
-  
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+	local score=0
+	local max_points=5
+	local details=""
+
+	local rev=$(helm history api-release -n nebula -o json 2>/dev/null | jq -r '.[-1].description' 2>/dev/null)
+	if [[ "$rev" == *"Rollback to 1"* ]]; then
+		((score += 5))
+		details+="Release rolled back to 1. "
+	else
+		details+="Release not rolled back to 1. "
+	fi
+
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q6() {
-  local score=0
-  local max_points=5
-  local details=""
-  
-  if resource_exists "deployment" "slow-start-app" "shadow"; then
-    ((score+=2))
-    
-    local min_ready=$(kubectl get deployment slow-start-app -n shadow -o jsonpath='{.spec.minReadySeconds}' 2>/dev/null)
-    if [ "$min_ready" == "20" ]; then
-      ((score+=3))
-      details+="minReadySeconds is 20. "
-    else
-      details+="minReadySeconds is not 20 ($min_ready). "
-    fi
-  else
-    details+="Deployment slow-start-app not found in shadow namespace. "
-  fi
-  
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+	local score=0
+	local max_points=5
+	local details=""
+
+	if resource_exists "deployment" "slow-start-app" "shadow"; then
+		((score += 2))
+
+		local min_ready=$(kubectl get deployment slow-start-app -n shadow -o jsonpath='{.spec.minReadySeconds}' 2>/dev/null)
+		if [ "$min_ready" == "20" ]; then
+			((score += 3))
+			details+="minReadySeconds is 20. "
+		else
+			details+="minReadySeconds is not 20 ($min_ready). "
+		fi
+	else
+		details+="Deployment slow-start-app not found in shadow namespace. "
+	fi
+
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q7() {
-  local score=0
-  local max_points=5
-  local details=""
-  
-  if resource_exists "deployment" "critical-processor" "nightfall"; then
-    local paused=$(kubectl get deployment critical-processor -n nightfall -o jsonpath='{.spec.paused}' 2>/dev/null)
-    if [ "$paused" == "true" ]; then
-      ((score+=5))
-      details+="Deployment is paused. "
-    else
-      details+="Deployment is not paused. "
-    fi
-  else
-    details+="Deployment critical-processor not found in nightfall namespace. "
-  fi
-  
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+	local score=0
+	local max_points=5
+	local details=""
+
+	if resource_exists "deployment" "critical-processor" "nightfall"; then
+		local paused=$(kubectl get deployment critical-processor -n nightfall -o jsonpath='{.spec.paused}' 2>/dev/null)
+		if [ "$paused" == "true" ]; then
+			((score += 5))
+			details+="Deployment is paused. "
+		else
+			details+="Deployment is not paused. "
+		fi
+	else
+		details+="Deployment critical-processor not found in nightfall namespace. "
+	fi
+
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q8() {
-  local score=0
-  local max_points=6
-  local details=""
-  
-  if [ -f "$EXAM_DIR/q8/kustomization.yaml" ] && [ -f "$EXAM_DIR/q8/patch.json" ]; then
-    ((score+=2))
-    if grep -q "patch.json" "$EXAM_DIR/q8/kustomization.yaml"; then
-      ((score+=2))
-      details+="patch.json referenced in kustomization. "
-    fi
-    if grep -q "production" "$EXAM_DIR/q8/patch.json" && grep -q "MODE" "$EXAM_DIR/q8/patch.json"; then
-      ((score+=2))
-      details+="Patch contains MODE=production. "
-    fi
-  else
-    details+="Files patch.json or kustomization.yaml missing. "
-  fi
-  
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+	local score=0
+	local max_points=6
+	local details=""
+
+	if [ -f "$EXAM_DIR/q8/kustomization.yaml" ] && [ -f "$EXAM_DIR/q8/patch.json" ]; then
+		((score += 2))
+		if grep -q "patch.json" "$EXAM_DIR/q8/kustomization.yaml"; then
+			((score += 2))
+			details+="patch.json referenced in kustomization. "
+		fi
+		if grep -q "production" "$EXAM_DIR/q8/patch.json" && grep -q "MODE" "$EXAM_DIR/q8/patch.json"; then
+			((score += 2))
+			details+="Patch contains MODE=production. "
+		fi
+	else
+		details+="Files patch.json or kustomization.yaml missing. "
+	fi
+
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q9() {
-  local score=0
-  local max_points=5
-  local details=""
-  
-  if resource_exists "pod" "metrics-gatherer" "starlight"; then
-    local img=$(kubectl get pod metrics-gatherer -n starlight -o jsonpath='{.spec.containers[0].image}' 2>/dev/null)
-    local status=$(kubectl get pod metrics-gatherer -n starlight -o jsonpath='{.status.phase}' 2>/dev/null)
-    
-    if [[ "$img" != *"non-existent"* ]]; then
-      ((score+=3))
-      details+="Image corrected. "
-    fi
-    if [ "$status" == "Running" ]; then
-      ((score+=2))
-      details+="Pod is running. "
-    fi
-  else
-    details+="Pod metrics-gatherer not found. "
-  fi
-  
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+	local score=0
+	local max_points=5
+	local details=""
+
+	if resource_exists "pod" "metrics-gatherer" "starlight"; then
+		local img=$(kubectl get pod metrics-gatherer -n starlight -o jsonpath='{.spec.containers[0].image}' 2>/dev/null)
+		local status=$(kubectl get pod metrics-gatherer -n starlight -o jsonpath='{.status.phase}' 2>/dev/null)
+
+		if [[ "$img" != *"non-existent"* ]]; then
+			((score += 3))
+			details+="Image corrected. "
+		fi
+		if [ "$status" == "Running" ]; then
+			((score += 2))
+			details+="Pod is running. "
+		fi
+	else
+		details+="Pod metrics-gatherer not found. "
+	fi
+
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q10() {
-  local score=0
-  local max_points=5
-  local details=""
-  
-  if [ -f "$EXAM_DIR/q10/cpu-usage.txt" ]; then
-    local content=$(cat "$EXAM_DIR/q10/cpu-usage.txt")
-    if [[ -n "$content" ]]; then
-      ((score+=5))
-      details+="Found CPU usage file. Content: $content. "
-    fi
-  else
-    details+="cpu-usage.txt not found. "
-  fi
-  
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+	local score=0
+	local max_points=5
+	local details=""
+
+	if [ -f "$EXAM_DIR/q10/cpu-usage.txt" ]; then
+		local content=$(cat "$EXAM_DIR/q10/cpu-usage.txt")
+		if [[ -n "$content" ]]; then
+			((score += 5))
+			details+="Found CPU usage file. Content: $content. "
+		fi
+	else
+		details+="cpu-usage.txt not found. "
+	fi
+
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q11() {
-  local score=0
-  local max_points=6
-  local details=""
-  
-  if resource_exists "pod" "logger" "lunar"; then
-    ((score+=2))
-    local vols=$(kubectl get pod logger -n lunar -o jsonpath='{.spec.volumes[*].emptyDir}' 2>/dev/null)
-    if [[ -n "$vols" ]]; then
-      ((score+=2))
-      details+="EmptyDir volume used. "
-    fi
-    local cont_count=$(kubectl get pod logger -n lunar -o jsonpath='{range .spec.containers[*]}{.name}{"\n"}{end}' | wc -l 2>/dev/null)
-    if [ "$cont_count" == "2" ]; then
-      ((score+=2))
-      details+="Two containers found. "
-    fi
-  else
-    details+="Pod logger not found. "
-  fi
-  
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+	local score=0
+	local max_points=6
+	local details=""
+
+	if resource_exists "pod" "logger" "lunar"; then
+		((score += 2))
+		local vols=$(kubectl get pod logger -n lunar -o jsonpath='{.spec.volumes[*].emptyDir}' 2>/dev/null)
+		if [[ -n "$vols" ]]; then
+			((score += 2))
+			details+="EmptyDir volume used. "
+		fi
+		local cont_count=$(kubectl get pod logger -n lunar -o jsonpath='{range .spec.containers[*]}{.name}{"\n"}{end}' | wc -l 2>/dev/null)
+		if [ "$cont_count" == "2" ]; then
+			((score += 2))
+			details+="Two containers found. "
+		fi
+	else
+		details+="Pod logger not found. "
+	fi
+
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q12() {
-  local score=0
-  local max_points=6
-  local details=""
-  
-  if resource_exists "pod" "combined-app" "crescent"; then
-    ((score+=2))
-    
-    local vols=$(kubectl get pod combined-app -n crescent -o jsonpath='{.spec.volumes[*].projected.sources}' 2>/dev/null)
-    if [[ "$vols" == *"db-creds"* ]]; then
-      ((score+=2))
-      details+="Secret db-creds projected. "
-    fi
-    if [[ "$vols" == *"app-config"* ]]; then
-      ((score+=2))
-      details+="ConfigMap app-config projected. "
-    fi
-  else
-    details+="Pod combined-app not found. "
-  fi
-  
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+	local score=0
+	local max_points=6
+	local details=""
+
+	if resource_exists "pod" "combined-app" "crescent"; then
+		((score += 2))
+
+		local vols=$(kubectl get pod combined-app -n crescent -o jsonpath='{.spec.volumes[*].projected.sources}' 2>/dev/null)
+		if [[ "$vols" == *"db-creds"* ]]; then
+			((score += 2))
+			details+="Secret db-creds projected. "
+		fi
+		if [[ "$vols" == *"app-config"* ]]; then
+			((score += 2))
+			details+="ConfigMap app-config projected. "
+		fi
+	else
+		details+="Pod combined-app not found. "
+	fi
+
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q13() {
-  local score=0
-  local max_points=4
-  local details=""
-  
-  if resource_exists "configmap" "static-config" "twilight"; then
-    ((score+=2))
-    local immutable=$(kubectl get cm static-config -n twilight -o jsonpath='{.immutable}' 2>/dev/null)
-    if [ "$immutable" == "true" ]; then
-      ((score+=2))
-      details+="ConfigMap is immutable. "
-    else
-      details+="ConfigMap is not immutable. "
-    fi
-  else
-    details+="ConfigMap static-config not found. "
-  fi
-  
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+	local score=0
+	local max_points=4
+	local details=""
+
+	if resource_exists "configmap" "static-config" "twilight"; then
+		((score += 2))
+		local immutable=$(kubectl get cm static-config -n twilight -o jsonpath='{.immutable}' 2>/dev/null)
+		if [ "$immutable" == "true" ]; then
+			((score += 2))
+			details+="ConfigMap is immutable. "
+		else
+			details+="ConfigMap is not immutable. "
+		fi
+	else
+		details+="ConfigMap static-config not found. "
+	fi
+
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q14() {
-  local score=0
-  local max_points=6
-  local details=""
-  
-  if resource_exists "pod" "secure-pod" "eclipse"; then
-    ((score+=2))
-    
-    local run_as=$(kubectl get pod secure-pod -n eclipse -o jsonpath='{.spec.securityContext.runAsUser}' 2>/dev/null)
-    if [ "$run_as" == "1000" ]; then
-      ((score+=2))
-      details+="runAsUser is 1000. "
-    fi
-    
-    local no_priv=$(kubectl get pod secure-pod -n eclipse -o jsonpath='{.spec.containers[0].securityContext.allowPrivilegeEscalation}' 2>/dev/null)
-    if [ "$no_priv" == "false" ]; then
-      ((score+=1))
-      details+="allowPrivilegeEscalation is false. "
-    fi
-    
-    local read_only=$(kubectl get pod secure-pod -n eclipse -o jsonpath='{.spec.containers[0].securityContext.readOnlyRootFilesystem}' 2>/dev/null)
-    if [ "$read_only" == "true" ]; then
-      ((score+=1))
-      details+="readOnlyRootFilesystem is true. "
-    fi
-  else
-    details+="Pod secure-pod not found. "
-  fi
-  
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+	local score=0
+	local max_points=6
+	local details=""
+
+	if resource_exists "pod" "secure-pod" "eclipse"; then
+		((score += 2))
+
+		local run_as=$(kubectl get pod secure-pod -n eclipse -o jsonpath='{.spec.securityContext.runAsUser}' 2>/dev/null)
+		if [ "$run_as" == "1000" ]; then
+			((score += 2))
+			details+="runAsUser is 1000. "
+		fi
+
+		local no_priv=$(kubectl get pod secure-pod -n eclipse -o jsonpath='{.spec.containers[0].securityContext.allowPrivilegeEscalation}' 2>/dev/null)
+		if [ "$no_priv" == "false" ]; then
+			((score += 1))
+			details+="allowPrivilegeEscalation is false. "
+		fi
+
+		local read_only=$(kubectl get pod secure-pod -n eclipse -o jsonpath='{.spec.containers[0].securityContext.readOnlyRootFilesystem}' 2>/dev/null)
+		if [ "$read_only" == "true" ]; then
+			((score += 1))
+			details+="readOnlyRootFilesystem is true. "
+		fi
+	else
+		details+="Pod secure-pod not found. "
+	fi
+
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q15() {
-  local score=0
-  local max_points=5
-  local details=""
-  
-  local val=$(kubectl get secret legacy-token -n shadow -o jsonpath='{.data.token}' 2>/dev/null | base64 -d 2>/dev/null)
-  if [ "$val" == "super-secret-v2" ]; then
-    ((score+=5))
-    details+="Token updated correctly. "
-  else
-    details+="Token not updated. "
-  fi
-  
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+	local score=0
+	local max_points=5
+	local details=""
+
+	local val=$(kubectl get secret legacy-token -n shadow -o jsonpath='{.data.token}' 2>/dev/null | base64 -d 2>/dev/null)
+	if [ "$val" == "super-secret-v2" ]; then
+		((score += 5))
+		details+="Token updated correctly. "
+	else
+		details+="Token not updated. "
+	fi
+
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q16() {
-  local score=0
-  local max_points=6
-  local details=""
-  
-  if resource_exists "resourcequota" "compute-quota" "nightfall"; then
-    ((score+=3))
-    
-    local pods=$(kubectl get resourcequota compute-quota -n nightfall -o jsonpath='{.spec.hard.pods}' 2>/dev/null)
-    local cpu=$(kubectl get resourcequota compute-quota -n nightfall -o jsonpath='{.spec.hard.requests\.cpu}' 2>/dev/null)
-    local mem=$(kubectl get resourcequota compute-quota -n nightfall -o jsonpath='{.spec.hard.limits\.memory}' 2>/dev/null)
-    
-    if [ "$pods" == "4" ] && [ "$cpu" == "2" ] && [ "$mem" == "4Gi" ]; then
-      ((score+=3))
-      details+="Quota limits correct. "
-    else
-      details+="Quota limits incorrect ($pods pods, $cpu cpu, $mem mem). "
-    fi
-  else
-    details+="ResourceQuota compute-quota not found. "
-  fi
-  
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+	local score=0
+	local max_points=6
+	local details=""
+
+	if resource_exists "resourcequota" "compute-quota" "nightfall"; then
+		((score += 3))
+
+		local pods=$(kubectl get resourcequota compute-quota -n nightfall -o jsonpath='{.spec.hard.pods}' 2>/dev/null)
+		local cpu=$(kubectl get resourcequota compute-quota -n nightfall -o jsonpath='{.spec.hard.requests\.cpu}' 2>/dev/null)
+		local mem=$(kubectl get resourcequota compute-quota -n nightfall -o jsonpath='{.spec.hard.limits\.memory}' 2>/dev/null)
+
+		if [ "$pods" == "4" ] && [ "$cpu" == "2" ] && [ "$mem" == "4Gi" ]; then
+			((score += 3))
+			details+="Quota limits correct. "
+		else
+			details+="Quota limits incorrect ($pods pods, $cpu cpu, $mem mem). "
+		fi
+	else
+		details+="ResourceQuota compute-quota not found. "
+	fi
+
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q17() {
-  local score=0
-  local max_points=5
-  local details=""
-  
-  if resource_exists "networkpolicy" "deny-external" "dusk"; then
-    ((score+=2))
-    
-    local egress_ports=$(kubectl get netpol deny-external -n dusk -o jsonpath='{.spec.egress[*].ports[*].port}' 2>/dev/null)
-    local egress_protos=$(kubectl get netpol deny-external -n dusk -o jsonpath='{.spec.egress[*].ports[*].protocol}' 2>/dev/null)
-    
-    if [ "$egress_ports" == "53" ] && [ "$egress_protos" == "UDP" ]; then
-      ((score+=3))
-      details+="Egress allows UDP 53. "
-    else
-      details+="Egress rules incorrect. "
-    fi
-  else
-    details+="NetworkPolicy deny-external not found. "
-  fi
-  
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+	local score=0
+	local max_points=5
+	local details=""
+
+	if resource_exists "networkpolicy" "deny-external" "dusk"; then
+		((score += 2))
+
+		local egress_ports=$(kubectl get netpol deny-external -n dusk -o jsonpath='{.spec.egress[*].ports[*].port}' 2>/dev/null)
+		local egress_protos=$(kubectl get netpol deny-external -n dusk -o jsonpath='{.spec.egress[*].ports[*].protocol}' 2>/dev/null)
+
+		if [ "$egress_ports" == "53" ] && [ "$egress_protos" == "UDP" ]; then
+			((score += 3))
+			details+="Egress allows UDP 53. "
+		else
+			details+="Egress rules incorrect. "
+		fi
+	else
+		details+="NetworkPolicy deny-external not found. "
+	fi
+
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q18() {
-  local score=0
-  local max_points=6
-  local details=""
-  
-  if resource_exists "ingress" "star-ingress" "starlight"; then
-    ((score+=2))
-    
-    local paths=$(kubectl get ingress star-ingress -n starlight -o jsonpath='{range .spec.rules[*].http.paths[*]}{.path}{" "}{.backend.service.name}{"\n"}{end}' 2>/dev/null)
-    if echo "$paths" | grep -q "/api api-svc"; then
-      ((score+=2))
-      details+="/api path mapped. "
-    fi
-    if echo "$paths" | grep -q "/web web-svc"; then
-      ((score+=2))
-      details+="/web path mapped. "
-    fi
-  else
-    details+="Ingress star-ingress not found. "
-  fi
-  
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+	local score=0
+	local max_points=6
+	local details=""
+
+	if resource_exists "ingress" "star-ingress" "starlight"; then
+		((score += 2))
+
+		local paths=$(kubectl get ingress star-ingress -n starlight -o jsonpath='{range .spec.rules[*].http.paths[*]}{.path}{" "}{.backend.service.name}{"\n"}{end}' 2>/dev/null)
+		if echo "$paths" | grep -q "/api api-svc"; then
+			((score += 2))
+			details+="/api path mapped. "
+		fi
+		if echo "$paths" | grep -q "/web web-svc"; then
+			((score += 2))
+			details+="/web path mapped. "
+		fi
+	else
+		details+="Ingress star-ingress not found. "
+	fi
+
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q19() {
-  local score=0
-  local max_points=5
-  local details=""
-  
-  if resource_exists "service" "db-ext-svc" "nebula"; then
-    ((score+=2))
-    
-    local type=$(kubectl get svc db-ext-svc -n nebula -o jsonpath='{.spec.type}' 2>/dev/null)
-    local ext_name=$(kubectl get svc db-ext-svc -n nebula -o jsonpath='{.spec.externalName}' 2>/dev/null)
-    
-    if [ "$type" == "ExternalName" ] && [ "$ext_name" == "database.external.example.com" ]; then
-      ((score+=3))
-      details+="Type and ExternalName correct. "
-    else
-      details+="Type ($type) or ExternalName ($ext_name) incorrect. "
-    fi
-  else
-    details+="Service db-ext-svc not found. "
-  fi
-  
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+	local score=0
+	local max_points=5
+	local details=""
+
+	if resource_exists "service" "db-ext-svc" "nebula"; then
+		((score += 2))
+
+		local type=$(kubectl get svc db-ext-svc -n nebula -o jsonpath='{.spec.type}' 2>/dev/null)
+		local ext_name=$(kubectl get svc db-ext-svc -n nebula -o jsonpath='{.spec.externalName}' 2>/dev/null)
+
+		if [ "$type" == "ExternalName" ] && [ "$ext_name" == "database.external.example.com" ]; then
+			((score += 3))
+			details+="Type and ExternalName correct. "
+		else
+			details+="Type ($type) or ExternalName ($ext_name) incorrect. "
+		fi
+	else
+		details+="Service db-ext-svc not found. "
+	fi
+
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q20() {
-  local score=0
-  local max_points=6
-  local details=""
-  
-  if [ -f "$EXAM_DIR/q20/nslookup.txt" ]; then
-    local content=$(cat "$EXAM_DIR/q20/nslookup.txt")
-    if echo "$content" | grep -q "kubernetes.default.svc.cluster.local"; then
-      ((score+=6))
-      details+="nslookup output valid. "
-    else
-      details+="nslookup output invalid or missing default service string. "
-    fi
-  else
-    details+="nslookup.txt not found. "
-  fi
-  
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+	local score=0
+	local max_points=6
+	local details=""
+
+	if [ -f "$EXAM_DIR/q20/nslookup.txt" ]; then
+		local content=$(cat "$EXAM_DIR/q20/nslookup.txt")
+		if echo "$content" | grep -q "kubernetes.default.svc.cluster.local"; then
+			((score += 6))
+			details+="nslookup output valid. "
+		else
+			details+="nslookup output invalid or missing default service string. "
+		fi
+	else
+		details+="nslookup.txt not found. "
+	fi
+
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }

--- a/exams/ckad-simulation12/templates/q1/Dockerfile
+++ b/exams/ckad-simulation12/templates/q1/Dockerfile
@@ -1,3 +1,2 @@
 FROM golang:1.20-alpine
 # Add instructions below
-

--- a/exams/ckad-simulation13/post-setup.sh
+++ b/exams/ckad-simulation13/post-setup.sh
@@ -1,17 +1,17 @@
 #!/bin/bash
 
 exam_post_setup() {
-    echo "Running post-setup for Simulation 13..."
-    local BASE_DIR="./exam/course"
-    
-    mkdir -p "$BASE_DIR/13/q1"
-    cat << 'EOF_FILE' > "$BASE_DIR/13/q1/Dockerfile"
+	echo "Running post-setup for Simulation 13..."
+	local BASE_DIR="./exam/course"
+
+	mkdir -p "$BASE_DIR/13/q1"
+	cat <<'EOF_FILE' >"$BASE_DIR/13/q1/Dockerfile"
 FROM nginx:1.22
 # TODO: Complete this manifest per the task instructions
 EOF_FILE
 
-    mkdir -p "$BASE_DIR/13/q4"
-    cat << 'EOF_FILE' > "$BASE_DIR/13/q4/pod.yaml"
+	mkdir -p "$BASE_DIR/13/q4"
+	cat <<'EOF_FILE' >"$BASE_DIR/13/q4/pod.yaml"
 apiVersion: v1
 kind: Pod
 metadata:
@@ -23,18 +23,18 @@ spec:
 # TODO: Complete this manifest per the task instructions
 EOF_FILE
 
-    mkdir -p "$BASE_DIR/13/q5/storm-chart/templates"
-    cat << 'EOF_FILE' > "$BASE_DIR/13/q5/storm-chart/Chart.yaml"
+	mkdir -p "$BASE_DIR/13/q5/storm-chart/templates"
+	cat <<'EOF_FILE' >"$BASE_DIR/13/q5/storm-chart/Chart.yaml"
 apiVersion: v2
 name: storm-chart
 version: 0.1.0
 EOF_FILE
-    cat << 'EOF_FILE' > "$BASE_DIR/13/q5/storm-chart/values.yaml"
+	cat <<'EOF_FILE' >"$BASE_DIR/13/q5/storm-chart/values.yaml"
 replicaCount: 1
 image:
   tag: "v1.0.0"
 EOF_FILE
-    cat << 'EOF_FILE' > "$BASE_DIR/13/q5/storm-chart/templates/deployment.yaml"
+	cat <<'EOF_FILE' >"$BASE_DIR/13/q5/storm-chart/templates/deployment.yaml"
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -54,9 +54,8 @@ spec:
         image: "nginx:{{ .Values.image.tag }}"
 EOF_FILE
 
-
-    mkdir -p "$BASE_DIR/13/q8"
-    cat << 'EOF_FILE' > "$BASE_DIR/13/q8/deployment.yaml"
+	mkdir -p "$BASE_DIR/13/q8"
+	cat <<'EOF_FILE' >"$BASE_DIR/13/q8/deployment.yaml"
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -76,9 +75,9 @@ spec:
         image: nginx
 EOF_FILE
 
-    mkdir -p "$BASE_DIR/13/q10"
-    
-    mkdir -p "$BASE_DIR/13/q20"
-    
-    return 0
+	mkdir -p "$BASE_DIR/13/q10"
+
+	mkdir -p "$BASE_DIR/13/q20"
+
+	return 0
 }

--- a/exams/ckad-simulation13/questions.md
+++ b/exams/ckad-simulation13/questions.md
@@ -25,11 +25,13 @@
 | **Resources** | Docker Image |
 
 ### Task
+
 There is a Dockerfile located at `./exam/course/13/q1/Dockerfile`.
 Build a container image using this Dockerfile and tag it as `localhost:5000/fujin-api:v2`.
 Push the built image to the local registry at `localhost:5000`.
 
 ---
+
 ## Question 2 | Sidecar Logging Container
 
 |                          |                                   |
@@ -41,12 +43,14 @@ Push the built image to the local registry at `localhost:5000`.
 | **Resources** | Pod |
 
 ### Task
+
 An application is running in a pod named `wind-logger` in the `gale` namespace. It generates logs in a format that is not easily parsable by our central logging system.
 Modify the pod to include an adapter container using the image `busybox:1.31.1`.
-The main container `app` writes logs to `/var/log/wind.log`. The adapter container should mount the same volume, tail the log file, and output each line prepended with `[WIND-LOG] ` to stdout using `tail -f /var/log/wind.log | sed 's/^/[WIND-LOG] /'`.
+The main container `app` writes logs to `/var/log/wind.log`. The adapter container should mount the same volume, tail the log file, and output each line prepended with `[WIND-LOG]` to stdout using `tail -f /var/log/wind.log | sed 's/^/[WIND-LOG] /'`.
 Make sure the adapter container is named `adapter` and both containers share a volume named `logs` mounted at `/var/log`. The pod is already created but might need to be replaced.
 
 ---
+
 ## Question 3 | Batch Job Processing
 
 |                          |                                   |
@@ -58,11 +62,13 @@ Make sure the adapter container is named `adapter` and both containers share a v
 | **Resources** | Job |
 
 ### Task
+
 Create a Job named `storm-processor` in the `breeze` namespace.
 The Job should use the `busybox:1.31.1` image and execute the command: `sh -c 'sleep 2; echo "Processing storm data"'`.
 Configure the Job to run a total of `6` successful completions, with `3` pods running in parallel.
 
 ---
+
 ## Question 4 | Fix Deployment CrashLoopBackOff
 
 |                          |                                   |
@@ -75,12 +81,14 @@ Configure the Job to run a total of `6` successful completions, with `3` pods ru
 | **File to create** | `./exam/course/13/q4/pod.yaml` |
 
 ### Task
+
 There is a deployment named `tempest-app` in the `tempest` namespace.
 Extract its pod template and create a standalone Pod named `tempest-debug` in the `tempest` namespace.
 The `tempest-debug` Pod should have the exact same container specifications (image, ports, env vars) as the deployment's pod template, but change the container's command to `['sleep', '3600']`.
 Save the YAML definition used to create this Pod at `./exam/course/13/q4/pod.yaml`.
 
 ---
+
 ## Question 5 | Helm Release Upgrade
 
 |                          |                                   |
@@ -92,11 +100,13 @@ Save the YAML definition used to create this Pod at `./exam/course/13/q4/pod.yam
 | **Resources** | Helm Release |
 
 ### Task
+
 A Helm chart has been deployed to the `typhoon` namespace with the release name `storm-app`.
 Update the release `storm-app` using the chart located at `./exam/course/13/q5/storm-chart`.
 Override the replica count to `3` and change the image tag to `v2.0.0` during the upgrade.
 
 ---
+
 ## Question 6 | Rolling Update Strategy
 
 |                          |                                   |
@@ -108,11 +118,13 @@ Override the replica count to `3` and change the image tag to `v2.0.0` during th
 | **Resources** | Deployment |
 
 ### Task
+
 Update the existing deployment named `cyclone-web` in the `cyclone` namespace.
 Change its `revisionHistoryLimit` to `2`.
 Then perform a rolling update to change the image of the container to `nginx:1.23.1`.
 
 ---
+
 ## Question 7 | Blue-Green Deployment Switch
 
 |                          |                                   |
@@ -124,11 +136,13 @@ Then perform a rolling update to change the image of the container to `nginx:1.2
 | **Resources** | Service, Deployment |
 
 ### Task
+
 In the `zephyr` namespace, a blue-green deployment is currently active. The service `zephyr-svc` is routing traffic to the `blue` deployment.
 Switch the traffic to the `green` deployment by updating the service's selector.
 Ensure that the `zephyr-svc` routes all traffic to pods with the label `version: green`.
 
 ---
+
 ## Question 8 | Kustomize Apply
 
 |                          |                                   |
@@ -141,6 +155,7 @@ Ensure that the `zephyr-svc` routes all traffic to pods with the label `version:
 | **File to create** | `./exam/course/13/q8/kustomization.yaml` |
 
 ### Task
+
 A Kustomization directory is located at `./exam/course/13/q8/`.
 Add a Kustomization file (`kustomization.yaml`) in that directory.
 It should include the `deployment.yaml` file located in the same directory as a resource.
@@ -148,6 +163,7 @@ Also, generate a ConfigMap named `tornado-config` from a literal value `WIND_SPE
 Then apply the Kustomization to the `tornado` namespace.
 
 ---
+
 ## Question 9 | OOMKilled Pod Troubleshooting
 
 |                          |                                   |
@@ -159,10 +175,12 @@ Then apply the Kustomization to the `tornado` namespace.
 | **Resources** | Pod |
 
 ### Task
+
 A pod named `memory-hog` in the `mistral` namespace is repeatedly crashing with an `OOMKilled` status.
 Investigate and fix the issue by increasing the memory limit of the container named `hog` to `256Mi`. The memory request should remain unchanged at `64Mi`.
 
 ---
+
 ## Question 10 | Top Memory-Consuming Pods
 
 |                          |                                   |
@@ -175,10 +193,12 @@ Investigate and fix the issue by increasing the memory limit of the container na
 | **File to create** | `./exam/course/13/q10/top-pods.txt` |
 
 ### Task
+
 Identify the top 3 pods in the `sirocco` namespace that are consuming the most memory.
 Write the names of these pods (just the pod names, one per line) to `./exam/course/13/q10/top-pods.txt`, sorted from highest memory consumption to lowest.
 
 ---
+
 ## Question 11 | Liveness and Readiness Probes
 
 |                          |                                   |
@@ -190,12 +210,14 @@ Write the names of these pods (just the pod names, one per line) to `./exam/cour
 | **Resources** | Pod |
 
 ### Task
+
 Create a Pod named `monsoon-checker` in the `monsoon` namespace using the image `busybox:1.31.1`.
 The container should run the command `sh -c 'touch /tmp/ready && sleep 3600'`.
 Configure a readiness probe for the container that uses the `exec` action to run `cat /tmp/ready`.
 Set the initial delay to `5` seconds and period to `10` seconds.
 
 ---
+
 ## Question 12 | Secret from File
 
 |                          |                                   |
@@ -207,11 +229,13 @@ Set the initial delay to `5` seconds and period to `10` seconds.
 | **Resources** | Pod, Secret |
 
 ### Task
+
 Create a Secret named `gale-secret` in the `gale` namespace with a key `password.txt` containing the value `super-secret-wind`.
 Create a Pod named `secret-reader` in the `gale` namespace using image `alpine:3.14` and command `sleep 3600`.
 Mount the Secret into the pod such that only the file `password.txt` appears at `/etc/secrets/password.txt` without deleting any other files that might exist in `/etc/secrets` (use `subPath`).
 
 ---
+
 ## Question 13 | Role and RoleBinding
 
 |                          |                                   |
@@ -223,10 +247,12 @@ Mount the Secret into the pod such that only the file `password.txt` appears at 
 | **Resources** | Role, RoleBinding |
 
 ### Task
+
 Create a Role named `breeze-manager` in the `breeze` namespace that grants `create`, `delete`, `list`, and `watch` permissions on `deployments` and `statefulsets` (which are in the `apps` API group).
 Create a RoleBinding named `breeze-manager-binding` in the same namespace binding this Role to a ServiceAccount named `breeze-admin` (the ServiceAccount already exists).
 
 ---
+
 ## Question 14 | Pod with Volume and SecurityContext
 
 |                          |                                   |
@@ -238,10 +264,12 @@ Create a RoleBinding named `breeze-manager-binding` in the same namespace bindin
 | **Resources** | Pod |
 
 ### Task
+
 Create a Pod named `secure-storage` in the `tempest` namespace using the image `nginx:1.23.1`.
 Configure the pod's security context so that all processes in the containers run with the filesystem group (`fsGroup`) set to `2000`.
 
 ---
+
 ## Question 15 | LimitRange Configuration
 
 |                          |                                   |
@@ -253,8 +281,10 @@ Configure the pod's security context so that all processes in the containers run
 | **Resources** | LimitRange |
 
 ### Task
+
 Create a LimitRange named `cyclone-limits` in the `cyclone` namespace.
 It should enforce the following constraints for Pods:
+
 - Maximum memory: `500Mi`
 - Minimum memory: `100Mi`
 For Containers:
@@ -262,6 +292,7 @@ For Containers:
 - Default CPU request: `200m`
 
 ---
+
 ## Question 16 | Disable Default ServiceAccount Automount
 
 |                          |                                   |
@@ -273,9 +304,11 @@ For Containers:
 | **Resources** | Pod |
 
 ### Task
+
 Update the pod `zephyr-api` in the `zephyr` namespace so that it does NOT automatically mount the default ServiceAccount token. (You may need to recreate the pod).
 
 ---
+
 ## Question 17 | Egress NetworkPolicy for DNS
 
 |                          |                                   |
@@ -287,12 +320,14 @@ Update the pod `zephyr-api` in the `zephyr` namespace so that it does NOT automa
 | **Resources** | NetworkPolicy |
 
 ### Task
+
 Create a NetworkPolicy named `allow-dns-egress` in the `typhoon` namespace.
 It should apply to pods with the label `role: worker`.
 Allow egress traffic only to port `53` (TCP and UDP) on all destinations.
 Ensure all other egress traffic from these pods is denied.
 
 ---
+
 ## Question 18 | Ingress with Path Routing
 
 |                          |                                   |
@@ -304,13 +339,16 @@ Ensure all other egress traffic from these pods is denied.
 | **Resources** | Ingress |
 
 ### Task
+
 Create an Ingress named `tornado-ingress` in the `tornado` namespace.
 It should route traffic for host `tornado.dojo.com` as follows:
+
 - Path `/api` routes to service `api-svc` on port `8080`.
 - Path `/web` routes to service `web-svc` on port `80`.
 Assume path type `Prefix` for both.
 
 ---
+
 ## Question 19 | Headless Service for StatefulSet
 
 |                          |                                   |
@@ -322,10 +360,12 @@ Assume path type `Prefix` for both.
 | **Resources** | Service |
 
 ### Task
+
 There is a StatefulSet named `mistral-db` in the `mistral` namespace that expects a headless service.
 Create a headless service named `mistral-db-headless` in the `mistral` namespace that targets pods with label `app: mistral-db`. The service should expose port `3306`.
 
 ---
+
 ## Question 20 | Debug Service Connectivity
 
 |                          |                                   |
@@ -338,6 +378,7 @@ Create a headless service named `mistral-db-headless` in the `mistral` namespace
 | **File to create** | `./exam/course/13/q20/svc-env.txt` |
 
 ### Task
+
 There is a pod named `sirocco-app` and a service named `sirocco-backend` in the `sirocco` namespace.
 When the pod was started, Kubernetes automatically injected environment variables for the service.
 Find the name of the environment variable that stores the IP address of the `sirocco-backend` service inside the `sirocco-app` pod.

--- a/exams/ckad-simulation13/scoring-functions.sh
+++ b/exams/ckad-simulation13/scoring-functions.sh
@@ -6,406 +6,406 @@ source "$SCRIPT_DIR/../../scripts/lib/common.sh" 2>/dev/null || true
 EXAM_DIR="./exam/course/13"
 
 score_q1() {
-  local score=0
-  local max_points=5
-  local details=""
-  
-  if curl -s http://localhost:5000/v2/fujin-api/tags/list 2>/dev/null | grep -q 'v2'; then
-    score=$((score + 5))
-    details="Image fujin-api:v2 pushed to local registry"
-  else
-    details="Image fujin-api:v2 not found in registry"
-  fi
-  
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+	local score=0
+	local max_points=5
+	local details=""
+
+	if curl -s http://localhost:5000/v2/fujin-api/tags/list 2>/dev/null | grep -q 'v2'; then
+		score=$((score + 5))
+		details="Image fujin-api:v2 pushed to local registry"
+	else
+		details="Image fujin-api:v2 not found in registry"
+	fi
+
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q2() {
-  local score=0
-  local max_points=6
-  local details=""
-  
-  if resource_exists pod wind-logger gale; then
-    local adapter=$(kubectl get pod wind-logger -n gale -o jsonpath='{.spec.containers[?(@.name=="adapter")].name}')
-    local mnt=$(kubectl get pod wind-logger -n gale -o jsonpath='{.spec.containers[?(@.name=="adapter")].volumeMounts[?(@.mountPath=="/var/log")].name}')
-    if [ "$adapter" == "adapter" ]; then
-      score=$((score + 3))
-      details="Adapter container exists"
-      if [ "$mnt" == "logs" ]; then
-        score=$((score + 3))
-        details="$details; Volume mounted correctly"
-      fi
-    else
-      details="Adapter container not found"
-    fi
-  else
-    details="Pod wind-logger not found"
-  fi
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+	local score=0
+	local max_points=6
+	local details=""
+
+	if resource_exists pod wind-logger gale; then
+		local adapter=$(kubectl get pod wind-logger -n gale -o jsonpath='{.spec.containers[?(@.name=="adapter")].name}')
+		local mnt=$(kubectl get pod wind-logger -n gale -o jsonpath='{.spec.containers[?(@.name=="adapter")].volumeMounts[?(@.mountPath=="/var/log")].name}')
+		if [ "$adapter" == "adapter" ]; then
+			score=$((score + 3))
+			details="Adapter container exists"
+			if [ "$mnt" == "logs" ]; then
+				score=$((score + 3))
+				details="$details; Volume mounted correctly"
+			fi
+		else
+			details="Adapter container not found"
+		fi
+	else
+		details="Pod wind-logger not found"
+	fi
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q3() {
-  local score=0
-  local max_points=5
-  local details=""
-  
-  if resource_exists job storm-processor breeze; then
-    local comps=$(kubectl get job storm-processor -n breeze -o jsonpath='{.spec.completions}')
-    local para=$(kubectl get job storm-processor -n breeze -o jsonpath='{.spec.parallelism}')
-    if [ "$comps" == "6" ] && [ "$para" == "3" ]; then
-      score=$((score + 5))
-      details="Job completions and parallelism are correct"
-    else
-      details="Job configuration is incorrect"
-    fi
-  else
-    details="Job storm-processor not found"
-  fi
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+	local score=0
+	local max_points=5
+	local details=""
+
+	if resource_exists job storm-processor breeze; then
+		local comps=$(kubectl get job storm-processor -n breeze -o jsonpath='{.spec.completions}')
+		local para=$(kubectl get job storm-processor -n breeze -o jsonpath='{.spec.parallelism}')
+		if [ "$comps" == "6" ] && [ "$para" == "3" ]; then
+			score=$((score + 5))
+			details="Job completions and parallelism are correct"
+		else
+			details="Job configuration is incorrect"
+		fi
+	else
+		details="Job storm-processor not found"
+	fi
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q4() {
-  local score=0
-  local max_points=6
-  local details=""
-  
-  if resource_exists pod tempest-debug tempest; then
-    local cmd=$(kubectl get pod tempest-debug -n tempest -o jsonpath='{.spec.containers[0].command[0]}')
-    if [ "$cmd" == "sleep" ]; then
-      score=$((score + 3))
-      details="Pod created with correct command"
-    else
-      details="Pod created but command is incorrect"
-    fi
-  else
-    details="Pod tempest-debug not found"
-  fi
-  
-  if [ -f "$LOCAL_PATH_PREFIX/13/q4/pod.yaml" ]; then
-    score=$((score + 3))
-    details="$details; File created"
-  else
-    details="$details; File not created"
-  fi
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+	local score=0
+	local max_points=6
+	local details=""
+
+	if resource_exists pod tempest-debug tempest; then
+		local cmd=$(kubectl get pod tempest-debug -n tempest -o jsonpath='{.spec.containers[0].command[0]}')
+		if [ "$cmd" == "sleep" ]; then
+			score=$((score + 3))
+			details="Pod created with correct command"
+		else
+			details="Pod created but command is incorrect"
+		fi
+	else
+		details="Pod tempest-debug not found"
+	fi
+
+	if [ -f "$LOCAL_PATH_PREFIX/13/q4/pod.yaml" ]; then
+		score=$((score + 3))
+		details="$details; File created"
+	else
+		details="$details; File not created"
+	fi
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q5() {
-  local score=0
-  local max_points=5
-  local details=""
-  
-  local deploy_name=$(kubectl get deploy -n typhoon -o name | grep storm-app | head -n 1)
-  if [ -n "$deploy_name" ]; then
-    local reps=$(kubectl get $deploy_name -n typhoon -o jsonpath='{.spec.replicas}')
-    local img=$(kubectl get $deploy_name -n typhoon -o jsonpath='{.spec.template.spec.containers[0].image}')
-    if [ "$reps" == "3" ]; then
-      score=$((score + 2))
-      details="Replicas correct"
-    fi
-    if [[ "$img" == *"v2.0.0"* ]]; then
-      score=$((score + 3))
-      details="$details; Image correct"
-    fi
-  else
-    details="Helm deployment not found"
-  fi
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+	local score=0
+	local max_points=5
+	local details=""
+
+	local deploy_name=$(kubectl get deploy -n typhoon -o name | grep storm-app | head -n 1)
+	if [ -n "$deploy_name" ]; then
+		local reps=$(kubectl get $deploy_name -n typhoon -o jsonpath='{.spec.replicas}')
+		local img=$(kubectl get $deploy_name -n typhoon -o jsonpath='{.spec.template.spec.containers[0].image}')
+		if [ "$reps" == "3" ]; then
+			score=$((score + 2))
+			details="Replicas correct"
+		fi
+		if [[ "$img" == *"v2.0.0"* ]]; then
+			score=$((score + 3))
+			details="$details; Image correct"
+		fi
+	else
+		details="Helm deployment not found"
+	fi
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q6() {
-  local score=0
-  local max_points=5
-  local details=""
-  
-  if resource_exists deploy cyclone-web cyclone; then
-    local rev=$(kubectl get deploy cyclone-web -n cyclone -o jsonpath='{.spec.revisionHistoryLimit}')
-    local img=$(kubectl get deploy cyclone-web -n cyclone -o jsonpath='{.spec.template.spec.containers[0].image}')
-    if [ "$rev" == "2" ] && [ "$img" == "nginx:1.23.1" ]; then
-      score=$((score + 5))
-      details="Deployment updated correctly"
-    else
-      details="Deployment properties incorrect"
-    fi
-  else
-    details="Deployment cyclone-web not found"
-  fi
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+	local score=0
+	local max_points=5
+	local details=""
+
+	if resource_exists deploy cyclone-web cyclone; then
+		local rev=$(kubectl get deploy cyclone-web -n cyclone -o jsonpath='{.spec.revisionHistoryLimit}')
+		local img=$(kubectl get deploy cyclone-web -n cyclone -o jsonpath='{.spec.template.spec.containers[0].image}')
+		if [ "$rev" == "2" ] && [ "$img" == "nginx:1.23.1" ]; then
+			score=$((score + 5))
+			details="Deployment updated correctly"
+		else
+			details="Deployment properties incorrect"
+		fi
+	else
+		details="Deployment cyclone-web not found"
+	fi
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q7() {
-  local score=0
-  local max_points=6
-  local details=""
-  
-  if resource_exists svc zephyr-svc zephyr; then
-    local sel=$(kubectl get svc zephyr-svc -n zephyr -o jsonpath='{.spec.selector.version}')
-    if [ "$sel" == "green" ]; then
-      score=$((score + 6))
-      details="Service routes to green version"
-    else
-      details="Service selector is incorrect"
-    fi
-  else
-    details="Service zephyr-svc not found"
-  fi
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+	local score=0
+	local max_points=6
+	local details=""
+
+	if resource_exists svc zephyr-svc zephyr; then
+		local sel=$(kubectl get svc zephyr-svc -n zephyr -o jsonpath='{.spec.selector.version}')
+		if [ "$sel" == "green" ]; then
+			score=$((score + 6))
+			details="Service routes to green version"
+		else
+			details="Service selector is incorrect"
+		fi
+	else
+		details="Service zephyr-svc not found"
+	fi
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q8() {
-  local score=0
-  local max_points=6
-  local details=""
-  
-  local cm_name=$(kubectl get cm -n tornado -o name | grep tornado-config | head -n 1)
-  if [ -n "$cm_name" ]; then
-    score=$((score + 3))
-    details="ConfigMap created"
-  else
-    details="ConfigMap not found"
-  fi
-  if [ -f "$EXAM_DIR/q8/kustomization.yaml" ]; then
-    score=$((score + 3))
-    details="$details; kustomization.yaml created"
-  fi
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+	local score=0
+	local max_points=6
+	local details=""
+
+	local cm_name=$(kubectl get cm -n tornado -o name | grep tornado-config | head -n 1)
+	if [ -n "$cm_name" ]; then
+		score=$((score + 3))
+		details="ConfigMap created"
+	else
+		details="ConfigMap not found"
+	fi
+	if [ -f "$EXAM_DIR/q8/kustomization.yaml" ]; then
+		score=$((score + 3))
+		details="$details; kustomization.yaml created"
+	fi
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q9() {
-  local score=0
-  local max_points=5
-  local details=""
-  
-  if resource_exists pod memory-hog mistral; then
-    local lim=$(kubectl get pod memory-hog -n mistral -o jsonpath='{.spec.containers[0].resources.limits.memory}')
-    if [ "$lim" == "256Mi" ]; then
-      score=$((score + 5))
-      details="Memory limit updated correctly"
-    else
-      details="Memory limit is incorrect"
-    fi
-  else
-    details="Pod memory-hog not found"
-  fi
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+	local score=0
+	local max_points=5
+	local details=""
+
+	if resource_exists pod memory-hog mistral; then
+		local lim=$(kubectl get pod memory-hog -n mistral -o jsonpath='{.spec.containers[0].resources.limits.memory}')
+		if [ "$lim" == "256Mi" ]; then
+			score=$((score + 5))
+			details="Memory limit updated correctly"
+		else
+			details="Memory limit is incorrect"
+		fi
+	else
+		details="Pod memory-hog not found"
+	fi
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q10() {
-  local score=0
-  local max_points=5
-  local details=""
-  
-  if [ -f "$LOCAL_PATH_PREFIX/13/q10/top-pods.txt" ]; then
-    local lines=$(wc -l < "$LOCAL_PATH_PREFIX/13/q10/top-pods.txt")
-    if [ "$lines" -ge 3 ]; then
-      score=$((score + 5))
-      details="Top pods file created with content"
-    else
-      details="File does not have enough lines"
-    fi
-  else
-    details="top-pods.txt not found"
-  fi
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+	local score=0
+	local max_points=5
+	local details=""
+
+	if [ -f "$LOCAL_PATH_PREFIX/13/q10/top-pods.txt" ]; then
+		local lines=$(wc -l <"$LOCAL_PATH_PREFIX/13/q10/top-pods.txt")
+		if [ "$lines" -ge 3 ]; then
+			score=$((score + 5))
+			details="Top pods file created with content"
+		else
+			details="File does not have enough lines"
+		fi
+	else
+		details="top-pods.txt not found"
+	fi
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q11() {
-  local score=0
-  local max_points=6
-  local details=""
-  
-  if resource_exists pod monsoon-checker monsoon; then
-    local prob=$(kubectl get pod monsoon-checker -n monsoon -o jsonpath='{.spec.containers[0].readinessProbe.exec.command[0]}')
-    if [ "$prob" == "cat" ]; then
-      score=$((score + 6))
-      details="Readiness probe configured correctly"
-    else
-      details="Readiness probe is incorrect"
-    fi
-  else
-    details="Pod monsoon-checker not found"
-  fi
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+	local score=0
+	local max_points=6
+	local details=""
+
+	if resource_exists pod monsoon-checker monsoon; then
+		local prob=$(kubectl get pod monsoon-checker -n monsoon -o jsonpath='{.spec.containers[0].readinessProbe.exec.command[0]}')
+		if [ "$prob" == "cat" ]; then
+			score=$((score + 6))
+			details="Readiness probe configured correctly"
+		else
+			details="Readiness probe is incorrect"
+		fi
+	else
+		details="Pod monsoon-checker not found"
+	fi
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q12() {
-  local score=0
-  local max_points=6
-  local details=""
-  
-  if resource_exists pod secret-reader gale; then
-    local sub=$(kubectl get pod secret-reader -n gale -o jsonpath='{.spec.containers[0].volumeMounts[0].subPath}')
-    if [ "$sub" == "password.txt" ]; then
-      score=$((score + 6))
-      details="SubPath mounted correctly"
-    else
-      details="SubPath not used or incorrect"
-    fi
-  else
-    details="Pod secret-reader not found"
-  fi
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+	local score=0
+	local max_points=6
+	local details=""
+
+	if resource_exists pod secret-reader gale; then
+		local sub=$(kubectl get pod secret-reader -n gale -o jsonpath='{.spec.containers[0].volumeMounts[0].subPath}')
+		if [ "$sub" == "password.txt" ]; then
+			score=$((score + 6))
+			details="SubPath mounted correctly"
+		else
+			details="SubPath not used or incorrect"
+		fi
+	else
+		details="Pod secret-reader not found"
+	fi
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q13() {
-  local score=0
-  local max_points=5
-  local details=""
-  
-  if resource_exists role breeze-manager breeze; then
-    score=$((score + 2))
-    details="Role exists"
-  fi
-  if resource_exists rolebinding breeze-manager-binding breeze; then
-    score=$((score + 3))
-    details="$details; RoleBinding exists"
-  fi
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+	local score=0
+	local max_points=5
+	local details=""
+
+	if resource_exists role breeze-manager breeze; then
+		score=$((score + 2))
+		details="Role exists"
+	fi
+	if resource_exists rolebinding breeze-manager-binding breeze; then
+		score=$((score + 3))
+		details="$details; RoleBinding exists"
+	fi
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q14() {
-  local score=0
-  local max_points=5
-  local details=""
-  
-  if resource_exists pod secure-storage tempest; then
-    local fsg=$(kubectl get pod secure-storage -n tempest -o jsonpath='{.spec.securityContext.fsGroup}')
-    if [ "$fsg" == "2000" ]; then
-      score=$((score + 5))
-      details="fsGroup set correctly"
-    else
-      details="fsGroup is incorrect"
-    fi
-  else
-    details="Pod secure-storage not found"
-  fi
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+	local score=0
+	local max_points=5
+	local details=""
+
+	if resource_exists pod secure-storage tempest; then
+		local fsg=$(kubectl get pod secure-storage -n tempest -o jsonpath='{.spec.securityContext.fsGroup}')
+		if [ "$fsg" == "2000" ]; then
+			score=$((score + 5))
+			details="fsGroup set correctly"
+		else
+			details="fsGroup is incorrect"
+		fi
+	else
+		details="Pod secure-storage not found"
+	fi
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q15() {
-  local score=0
-  local max_points=6
-  local details=""
-  
-  if resource_exists limitrange cyclone-limits cyclone; then
-    score=$((score + 6))
-    details="LimitRange created"
-  else
-    details="LimitRange not found"
-  fi
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+	local score=0
+	local max_points=6
+	local details=""
+
+	if resource_exists limitrange cyclone-limits cyclone; then
+		score=$((score + 6))
+		details="LimitRange created"
+	else
+		details="LimitRange not found"
+	fi
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q16() {
-  local score=0
-  local max_points=5
-  local details=""
-  
-  if resource_exists pod zephyr-api zephyr; then
-    local auto=$(kubectl get pod zephyr-api -n zephyr -o jsonpath='{.spec.automountServiceAccountToken}')
-    if [ "$auto" == "false" ]; then
-      score=$((score + 5))
-      details="automountServiceAccountToken is false"
-    else
-      details="automountServiceAccountToken is not false"
-    fi
-  else
-    details="Pod zephyr-api not found"
-  fi
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+	local score=0
+	local max_points=5
+	local details=""
+
+	if resource_exists pod zephyr-api zephyr; then
+		local auto=$(kubectl get pod zephyr-api -n zephyr -o jsonpath='{.spec.automountServiceAccountToken}')
+		if [ "$auto" == "false" ]; then
+			score=$((score + 5))
+			details="automountServiceAccountToken is false"
+		else
+			details="automountServiceAccountToken is not false"
+		fi
+	else
+		details="Pod zephyr-api not found"
+	fi
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q17() {
-  local score=0
-  local max_points=6
-  local details=""
-  
-  if resource_exists netpol allow-dns-egress typhoon; then
-    local port=$(kubectl get netpol allow-dns-egress -n typhoon -o jsonpath='{.spec.egress[0].ports[0].port}')
-    if [ "$port" == "53" ]; then
-      score=$((score + 6))
-      details="NetworkPolicy created with correct port"
-    else
-      details="NetworkPolicy port incorrect"
-    fi
-  else
-    details="NetworkPolicy not found"
-  fi
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+	local score=0
+	local max_points=6
+	local details=""
+
+	if resource_exists netpol allow-dns-egress typhoon; then
+		local port=$(kubectl get netpol allow-dns-egress -n typhoon -o jsonpath='{.spec.egress[0].ports[0].port}')
+		if [ "$port" == "53" ]; then
+			score=$((score + 6))
+			details="NetworkPolicy created with correct port"
+		else
+			details="NetworkPolicy port incorrect"
+		fi
+	else
+		details="NetworkPolicy not found"
+	fi
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q18() {
-  local score=0
-  local max_points=6
-  local details=""
-  
-  if resource_exists ingress tornado-ingress tornado; then
-    local host=$(kubectl get ingress tornado-ingress -n tornado -o jsonpath='{.spec.rules[0].host}')
-    if [ "$host" == "tornado.dojo.com" ]; then
-      score=$((score + 6))
-      details="Ingress created with correct host"
-    else
-      details="Ingress host incorrect"
-    fi
-  else
-    details="Ingress not found"
-  fi
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+	local score=0
+	local max_points=6
+	local details=""
+
+	if resource_exists ingress tornado-ingress tornado; then
+		local host=$(kubectl get ingress tornado-ingress -n tornado -o jsonpath='{.spec.rules[0].host}')
+		if [ "$host" == "tornado.dojo.com" ]; then
+			score=$((score + 6))
+			details="Ingress created with correct host"
+		else
+			details="Ingress host incorrect"
+		fi
+	else
+		details="Ingress not found"
+	fi
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q19() {
-  local score=0
-  local max_points=5
-  local details=""
-  
-  if resource_exists svc mistral-db-headless mistral; then
-    local ip=$(kubectl get svc mistral-db-headless -n mistral -o jsonpath='{.spec.clusterIP}')
-    if [ "$ip" == "None" ]; then
-      score=$((score + 5))
-      details="Headless service created correctly"
-    else
-      details="Service is not headless"
-    fi
-  else
-    details="Service mistral-db-headless not found"
-  fi
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+	local score=0
+	local max_points=5
+	local details=""
+
+	if resource_exists svc mistral-db-headless mistral; then
+		local ip=$(kubectl get svc mistral-db-headless -n mistral -o jsonpath='{.spec.clusterIP}')
+		if [ "$ip" == "None" ]; then
+			score=$((score + 5))
+			details="Headless service created correctly"
+		else
+			details="Service is not headless"
+		fi
+	else
+		details="Service mistral-db-headless not found"
+	fi
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q20() {
-  local score=0
-  local max_points=6
-  local details=""
-  
-  if [ -f "$LOCAL_PATH_PREFIX/13/q20/svc-env.txt" ]; then
-    if grep -q "SIROCCO_BACKEND_SERVICE_HOST" "$LOCAL_PATH_PREFIX/13/q20/svc-env.txt"; then
-      score=$((score + 6))
-      details="Environment variable identified correctly"
-    else
-      details="Incorrect environment variable name"
-    fi
-  else
-    details="File svc-env.txt not found"
-  fi
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+	local score=0
+	local max_points=6
+	local details=""
+
+	if [ -f "$LOCAL_PATH_PREFIX/13/q20/svc-env.txt" ]; then
+		if grep -q "SIROCCO_BACKEND_SERVICE_HOST" "$LOCAL_PATH_PREFIX/13/q20/svc-env.txt"; then
+			score=$((score + 6))
+			details="Environment variable identified correctly"
+		else
+			details="Incorrect environment variable name"
+		fi
+	else
+		details="File svc-env.txt not found"
+	fi
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }

--- a/exams/ckad-simulation13/solutions.md
+++ b/exams/ckad-simulation13/solutions.md
@@ -1,6 +1,7 @@
 # CKAD Simulation 13 - Solutions (Dojo Fujin 🌬️)
 
 ---
+
 ## Question 1 | Kubernetes Practice
 
 ```bash
@@ -8,15 +9,18 @@ cd ./exam/course/13/q1
 docker build -t localhost:5000/fujin-api:v2 .
 docker push localhost:5000/fujin-api:v2
 ```
+
 **Explanation:** Build the container image from the provided Dockerfile and tag it appropriately. Then push it to the local registry.
 
 ---
+
 ## Question 2 | Kubernetes Practice
 
 ```bash
 kubectl get pod wind-logger -n gale -o yaml > wind.yaml
 # Edit wind.yaml to add the adapter container
 ```
+
 ```yaml
 # Add this under spec.containers:
   - name: adapter
@@ -26,35 +30,43 @@ kubectl get pod wind-logger -n gale -o yaml > wind.yaml
     - name: logs
       mountPath: /var/log
 ```
+
 ```bash
 kubectl replace --force -f wind.yaml
 ```
+
 **Explanation:** Extract the pod YAML, add the adapter container sharing the same volume mount, and force replace the pod since container changes aren't allowed dynamically.
 
 ---
+
 ## Question 3 | Kubernetes Practice
 
 ```bash
 kubectl create job storm-processor -n breeze --image=busybox:1.31.1 --dry-run=client -o yaml -- sh -c 'sleep 2; echo "Processing storm data"' > job.yaml
 # Edit job.yaml to add completions and parallelism
 ```
+
 ```yaml
 # Add under spec:
   completions: 6
   parallelism: 3
 ```
+
 ```bash
 kubectl apply -f job.yaml
 ```
+
 **Explanation:** Create a Job with specific completions and parallelism directly in the spec.
 
 ---
+
 ## Question 4 | Kubernetes Practice
 
 ```bash
 kubectl get deployment tempest-app -n tempest -o yaml > dep.yaml
 # Extract the pod template and create pod.yaml
 ```
+
 ```yaml
 apiVersion: v1
 kind: Pod
@@ -72,37 +84,46 @@ spec:
     - name: WIND_FORCE
       value: "high"
 ```
+
 ```bash
 kubectl apply -f ./exam/course/13/q4/pod.yaml
 ```
+
 **Explanation:** Extract the template from the deployment and wrap it in a Pod definition, changing only the requested command.
 
 ---
+
 ## Question 5 | Kubernetes Practice
 
 ```bash
 helm upgrade storm-app ./exam/course/13/q5/storm-chart -n typhoon --set replicaCount=3 --set image.tag=v2.0.0
 ```
+
 **Explanation:** Upgrade the helm release using `--set` to override values defined in `values.yaml`.
 
 ---
+
 ## Question 6 | Kubernetes Practice
 
 ```bash
 kubectl patch deployment cyclone-web -n cyclone -p '{"spec":{"revisionHistoryLimit":2}}'
 kubectl set image deployment/cyclone-web -n cyclone web=nginx:1.23.1
 ```
+
 **Explanation:** Patch the `revisionHistoryLimit` first, then trigger a rolling update by changing the image.
 
 ---
+
 ## Question 7 | Kubernetes Practice
 
 ```bash
 kubectl patch svc zephyr-svc -n zephyr -p '{"spec":{"selector":{"version":"green"}}}'
 ```
+
 **Explanation:** Patching the service selector routes traffic to the pods with the label `version: green`.
 
 ---
+
 ## Question 8 | Kubernetes Practice
 
 ```bash
@@ -119,9 +140,11 @@ configMapGenerator:
 EOF
 kubectl apply -k . -n tornado
 ```
+
 **Explanation:** Create `kustomization.yaml` defining the resource and configMapGenerator, then apply it using `kubectl apply -k`.
 
 ---
+
 ## Question 9 | Kubernetes Practice
 
 ```bash
@@ -129,9 +152,11 @@ kubectl get pod memory-hog -n mistral -o yaml > hog.yaml
 # Edit hog.yaml to update memory limits to 256Mi
 kubectl replace --force -f hog.yaml
 ```
+
 **Explanation:** Since it's crashing with OOMKilled, extract the configuration, increase the memory limit, and force replace.
 
 ---
+
 ## Question 10 | Kubernetes Practice
 
 ```bash
@@ -143,9 +168,11 @@ pod-2
 pod-3
 EOF
 ```
+
 **Explanation:** Use `kubectl top pods --sort-by=memory` to find the pods consuming the most memory.
 
 ---
+
 ## Question 11 | Kubernetes Practice
 
 ```bash
@@ -170,9 +197,11 @@ spec:
 EOF
 kubectl apply -f q11.yaml
 ```
+
 **Explanation:** Define a pod with an exec-based readiness probe using the exact requested parameters.
 
 ---
+
 ## Question 12 | Kubernetes Practice
 
 ```bash
@@ -199,9 +228,11 @@ spec:
 EOF
 kubectl apply -f q12.yaml
 ```
+
 **Explanation:** Create the secret, then define a pod mounting it using `subPath` to avoid overwriting the entire directory.
 
 ---
+
 ## Question 13 | Kubernetes Practice
 
 ```bash
@@ -211,9 +242,11 @@ kubectl create role breeze-manager -n breeze --verb=create,delete,list,watch --r
 kubectl create role breeze-manager -n breeze --verb=create,delete,list,watch --resource=deployments.apps,statefulsets.apps
 kubectl create rolebinding breeze-manager-binding -n breeze --role=breeze-manager --serviceaccount=breeze:breeze-admin
 ```
+
 **Explanation:** Use imperative commands to create the Role and RoleBinding mapping permissions to the service account.
 
 ---
+
 ## Question 14 | Kubernetes Practice
 
 ```bash
@@ -232,9 +265,11 @@ spec:
 EOF
 kubectl apply -f q14.yaml
 ```
+
 **Explanation:** Pod-level security context is used to set `fsGroup`.
 
 ---
+
 ## Question 15 | Kubernetes Practice
 
 ```bash
@@ -259,9 +294,11 @@ spec:
 EOF
 kubectl apply -f q15.yaml
 ```
+
 **Explanation:** Define a LimitRange containing constraints for both Pod (min/max) and Container (default/defaultRequest).
 
 ---
+
 ## Question 16 | Kubernetes Practice
 
 ```bash
@@ -269,9 +306,11 @@ kubectl get pod zephyr-api -n zephyr -o yaml > q16.yaml
 # Edit to add automountServiceAccountToken: false under spec
 kubectl replace --force -f q16.yaml
 ```
+
 **Explanation:** `automountServiceAccountToken: false` must be set at the Pod spec level.
 
 ---
+
 ## Question 17 | Kubernetes Practice
 
 ```bash
@@ -296,9 +335,11 @@ spec:
 EOF
 kubectl apply -f q17.yaml
 ```
+
 **Explanation:** Egress policy matching label, allowing only TCP/UDP port 53. Since egress is defined, all other egress traffic is denied.
 
 ---
+
 ## Question 18 | Kubernetes Practice
 
 ```bash
@@ -330,9 +371,11 @@ spec:
 EOF
 kubectl apply -f q18.yaml
 ```
+
 **Explanation:** Create standard Ingress definition mapping paths to specific backend services and ports.
 
 ---
+
 ## Question 19 | Kubernetes Practice
 
 ```bash
@@ -340,13 +383,16 @@ kubectl create service clusterip mistral-db-headless -n mistral --clusterip="Non
 # Edit selector to match app: mistral-db
 kubectl apply -f svc.yaml
 ```
+
 **Explanation:** A headless service sets `clusterIP: None`. Modify the generated selector to target the statefulset pods.
 
 ---
+
 ## Question 20 | Kubernetes Practice
 
 ```bash
 kubectl exec -it sirocco-app -n sirocco -- env | grep SIROCCO_BACKEND
 echo "SIROCCO_BACKEND_SERVICE_HOST" > ./exam/course/13/q20/svc-env.txt
 ```
+
 **Explanation:** Kubernetes injects variables mapping service IP (e.g. `[SERVICE_NAME]_SERVICE_HOST`). The file should contain this exact variable name.

--- a/exams/ckad-simulation14/post-setup.sh
+++ b/exams/ckad-simulation14/post-setup.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
 exam_post_setup() {
-  echo "Running post-setup for CKAD Simulation 14..."
-  
-  # Q5 Helm Chart setup
-  mkdir -p ./exam/course/14/q5/chart/templates
-  cat << 'EOF_FILE' > ./exam/course/14/q5/chart/Chart.yaml
+	echo "Running post-setup for CKAD Simulation 14..."
+
+	# Q5 Helm Chart setup
+	mkdir -p ./exam/course/14/q5/chart/templates
+	cat <<'EOF_FILE' >./exam/course/14/q5/chart/Chart.yaml
 apiVersion: v2
 name: thunder-web
 description: A Helm chart for Kubernetes
@@ -14,7 +14,7 @@ version: 0.1.0
 appVersion: "1.16.0"
 EOF_FILE
 
-  cat << 'EOF_FILE' > ./exam/course/14/q5/chart/values.yaml
+	cat <<'EOF_FILE' >./exam/course/14/q5/chart/values.yaml
 replicaCount: 1
 image:
   repository: nginx
@@ -22,7 +22,7 @@ image:
   tag: "1.16.0"
 EOF_FILE
 
-  cat << 'EOF_FILE' > ./exam/course/14/q5/chart/templates/deployment.yaml
+	cat <<'EOF_FILE' >./exam/course/14/q5/chart/templates/deployment.yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -45,7 +45,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
 EOF_FILE
 
-  cat << 'EOF_FILE' > ./exam/course/14/q5/chart/templates/_helpers.tpl
+	cat <<'EOF_FILE' >./exam/course/14/q5/chart/templates/_helpers.tpl
 {{- define "thunder-web.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
 {{- end }}
@@ -63,14 +63,14 @@ EOF_FILE
 {{- end }}
 EOF_FILE
 
-  # Q6 Deployment update to create a revision history
-  kubectl create deployment api-gateway --image=nginx:1.23 -n voltage
-  kubectl wait --for=condition=available deployment/api-gateway -n voltage --timeout=90s || true
-  kubectl set image deployment/api-gateway nginx=nginx:broken-tag-123 -n voltage --record=true
-  
-  # Q8 Base files
-  mkdir -p ./exam/course/14/q8/
-  cat << 'EOF_FILE' > ./exam/course/14/q8/deployment.yaml
+	# Q6 Deployment update to create a revision history
+	kubectl create deployment api-gateway --image=nginx:1.23 -n voltage
+	kubectl wait --for=condition=available deployment/api-gateway -n voltage --timeout=90s || true
+	kubectl set image deployment/api-gateway nginx=nginx:broken-tag-123 -n voltage --record=true
+
+	# Q8 Base files
+	mkdir -p ./exam/course/14/q8/
+	cat <<'EOF_FILE' >./exam/course/14/q8/deployment.yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -91,47 +91,46 @@ spec:
         command: ["sleep", "3600"]
 EOF_FILE
 
+	# === Auto-generated starter files ===
+	local BASE_DIR="./exam/course"
+	mkdir -p "$BASE_DIR/14/q1"
 
-  # === Auto-generated starter files ===
-  local BASE_DIR="./exam/course"
-  mkdir -p "$BASE_DIR/14/q1"
-    
-  mkdir -p "$BASE_DIR/14/q2"
-    
-  mkdir -p "$BASE_DIR/14/q3"
-    
-  mkdir -p "$BASE_DIR/14/q4"
-    
-  mkdir -p "$BASE_DIR/14/q5"
-  cat << 'EOF_FILE' > "$BASE_DIR/14/q5/output.yaml"
+	mkdir -p "$BASE_DIR/14/q2"
+
+	mkdir -p "$BASE_DIR/14/q3"
+
+	mkdir -p "$BASE_DIR/14/q4"
+
+	mkdir -p "$BASE_DIR/14/q5"
+	cat <<'EOF_FILE' >"$BASE_DIR/14/q5/output.yaml"
 # Rendered helm templates will go here
 EOF_FILE
-  
-  mkdir -p "$BASE_DIR/14/q8"
-  cat << 'EOF_FILE' > "$BASE_DIR/14/q8/kustomization.yaml"
+
+	mkdir -p "$BASE_DIR/14/q8"
+	cat <<'EOF_FILE' >"$BASE_DIR/14/q8/kustomization.yaml"
 resources:
   - deployment.yaml
 EOF_FILE
-  
-  mkdir -p "$BASE_DIR/14/q10"
-    
-  mkdir -p "$BASE_DIR/14/q11"
-    
-  mkdir -p "$BASE_DIR/14/q12"
-    
-  mkdir -p "$BASE_DIR/14/q13"
-    
-  mkdir -p "$BASE_DIR/14/q14"
-    
-  mkdir -p "$BASE_DIR/14/q15"
-  
-  mkdir -p "$BASE_DIR/14/q17"
-    
-  mkdir -p "$BASE_DIR/14/q18"
-    
-  mkdir -p "$BASE_DIR/14/q19"
-    
-  mkdir -p "$BASE_DIR/14/q20"
-    
-  return 0
+
+	mkdir -p "$BASE_DIR/14/q10"
+
+	mkdir -p "$BASE_DIR/14/q11"
+
+	mkdir -p "$BASE_DIR/14/q12"
+
+	mkdir -p "$BASE_DIR/14/q13"
+
+	mkdir -p "$BASE_DIR/14/q14"
+
+	mkdir -p "$BASE_DIR/14/q15"
+
+	mkdir -p "$BASE_DIR/14/q17"
+
+	mkdir -p "$BASE_DIR/14/q18"
+
+	mkdir -p "$BASE_DIR/14/q19"
+
+	mkdir -p "$BASE_DIR/14/q20"
+
+	return 0
 }

--- a/exams/ckad-simulation14/questions.md
+++ b/exams/ckad-simulation14/questions.md
@@ -25,7 +25,9 @@
 | **Resources** | Dockerfile |
 
 ### Task
+
 Create a Dockerfile in `./exam/course/14/q1/` that fulfills the following requirements:
+
 - Use `nginx:1.23-alpine` as the base image.
 - Add a `HEALTHCHECK` instruction that tests if the web server is responding.
 - The check should run the command `curl -f http://localhost/ || exit 1`.
@@ -45,7 +47,9 @@ Create a Dockerfile in `./exam/course/14/q1/` that fulfills the following requir
 | **Resources** | Pod |
 
 ### Task
+
 Create a Pod named `thunder-logger` in the `thunder` namespace.
+
 - The main container should be named `app-container`, using the `busybox` image, and run the command: `sh -c 'while true; do echo "INFO: Processing request"; sleep 2; echo "ERROR: Connection timeout"; sleep 3; done > /var/log/app.log'`
 - Mount an `emptyDir` volume at `/var/log` for the main container.
 - Add a sidecar container named `error-tailer`, using the `busybox` image.
@@ -64,7 +68,9 @@ Create a Pod named `thunder-logger` in the `thunder` namespace.
 | **Resources** | CronJob |
 
 ### Task
+
 Create a CronJob named `lightning-strike` in the `bolt` namespace.
+
 - It should run every 5 minutes (`*/5 * * * *`).
 - The job should use the `busybox` image and run the command `echo "Strike!"`.
 - Configure `startingDeadlineSeconds` to `15` seconds.
@@ -83,8 +89,10 @@ Create a CronJob named `lightning-strike` in the `bolt` namespace.
 | **Resources** | Pod |
 
 ### Task
+
 A Service named `database-svc` will be created in the `storm` namespace in the future.
 Create a Pod named `app-with-wait` in the `storm` namespace:
+
 - Main container: name `main-app`, image `nginx:alpine`.
 - Init container: name `wait-for-db`, image `busybox`.
 - The init container should run a command that repeatedly checks if `database-svc` is resolvable or reachable (e.g., using `nslookup database-svc` or `wget -qO- http://database-svc`), looping until it succeeds before the main container starts. (Use a simple shell loop with a sleep).
@@ -102,9 +110,11 @@ Create a Pod named `app-with-wait` in the `storm` namespace:
 | **Resources** | File |
 
 ### Task
+
 A helm chart is located at `/opt/course/14/q5/chart`.
 Render the helm templates using the release name `thunder-web` and namespace `surge`.
 Override the following values:
+
 - `replicaCount` to `3`
 - `image.tag` to `latest`
 Save the rendered output to `./exam/course/14/q5/output.yaml`.
@@ -123,6 +133,7 @@ Do NOT install the helm chart.
 | **Resources** | Deployment |
 
 ### Task
+
 There is a Deployment named `api-gateway` in the `voltage` namespace that has been updated a few times, and the current version is broken.
 Roll back the Deployment to revision `1`.
 Ensure the Deployment is successfully rolled back and running.
@@ -140,8 +151,10 @@ Ensure the Deployment is successfully rolled back and running.
 | **Resources** | Deployments, Service |
 
 ### Task
+
 In the `spark` namespace, a Service named `backend-svc` exists, routing traffic to a Deployment named `backend-v1` (with 4 replicas).
 You need to introduce a canary version:
+
 - Create a new Deployment named `backend-v2` in the `spark` namespace with `1` replica, using the `nginx:1.23` image.
 - Ensure the `backend-svc` distributes traffic to BOTH `backend-v1` and `backend-v2`. (Hint: check the labels of the existing service and deployment).
 - The traffic split should essentially be 4:1 (since v1 has 4 replicas and v2 has 1).
@@ -159,6 +172,7 @@ You need to introduce a canary version:
 | **Resources** | File |
 
 ### Task
+
 In `./exam/course/14/q8/`, there is a base deployment file `deployment.yaml`.
 Create a `kustomization.yaml` file in the same directory.
 Configure it to include `deployment.yaml` as a resource.
@@ -178,6 +192,7 @@ Apply the kustomization to the `charge` namespace using `kubectl apply -k`.
 | **Resources** | Pod |
 
 ### Task
+
 A Pod named `data-processor` in the `flash` namespace is stuck in a `CrashLoopBackOff`.
 Find the cause and fix it. The pod should be running successfully.
 (Hint: The application expects a specific configuration to listen on the correct port, or the probe might be misconfigured).
@@ -195,6 +210,7 @@ Find the cause and fix it. The pod should be running successfully.
 | **Resources** | File |
 
 ### Task
+
 List all events in the `strike` namespace, sorted by their creation timestamp (oldest first).
 Save the output (which should include at least the time, type, reason, and object name) to `./exam/course/14/q10/events.txt`.
 
@@ -211,8 +227,10 @@ Save the output (which should include at least the time, type, reason, and objec
 | **Resources** | Pod |
 
 ### Task
+
 Create a Pod named `complex-app` in the `plasma` namespace using the `nginx:alpine` image.
 Configure all three probe types for the container on port `80`:
+
 - **Startup Probe**: HTTP GET on `/`, wait for up to 30 seconds (e.g. failureThreshold: 30, periodSeconds: 1).
 - **Liveness Probe**: TCP Socket on port `80`, periodSeconds 10.
 - **Readiness Probe**: HTTP GET on `/`, periodSeconds 5, initialDelaySeconds 5.
@@ -230,9 +248,11 @@ Configure all three probe types for the container on port `80`:
 | **Resources** | Pod |
 
 ### Task
+
 Create a Pod named `env-info` in the `thunder` namespace using the `busybox` image.
 It should run the command `sleep 3600`.
 Use the Downward API to inject the following environment variables:
+
 - `POD_NAME`: the name of the pod (`metadata.name`)
 - `POD_NAMESPACE`: the namespace of the pod (`metadata.namespace`)
 
@@ -249,8 +269,10 @@ Use the Downward API to inject the following environment variables:
 | **Resources** | Pod |
 
 ### Task
+
 Create a Pod named `secure-net` in the `bolt` namespace using the `alpine` image, running `sleep 1d`.
 Configure the container's `securityContext` to:
+
 - Drop `ALL` capabilities.
 - Add the `NET_ADMIN` capability.
 
@@ -267,8 +289,10 @@ Configure the container's `securityContext` to:
 | **Resources** | Secret |
 
 ### Task
+
 Create a YAML manifest for a Secret named `db-credentials` in the `storm` namespace.
 Use the `stringData` field to define the following key-value pairs (do not use base64 encoding in the manifest):
+
 - `username`: `admin`
 - `password`: `supersecret123`
 Apply the YAML file to create the Secret.
@@ -286,6 +310,7 @@ Apply the YAML file to create the Secret.
 | **Resources** | Pod, ConfigMap |
 
 ### Task
+
 Create a ConfigMap named `app-args` in the `voltage` namespace with a key `mode` and value `verbose`.
 Create a Pod named `arg-reader` in the `voltage` namespace using the `busybox` image.
 The pod should run the command: `echo`
@@ -305,6 +330,7 @@ Use environment variables mapped from the ConfigMap to pass it to the `args` fie
 | **Resources** | ClusterRole, ClusterRoleBinding |
 
 ### Task
+
 Create a ClusterRole named `secret-reader` that can `get`, `watch`, and `list` resources of type `secrets`.
 Create a ClusterRoleBinding named `secret-reader-binding` to bind the `secret-reader` ClusterRole to a ServiceAccount named `app-sa` in the `spark` namespace. (You may need to create the ServiceAccount if it doesn't exist).
 
@@ -321,9 +347,11 @@ Create a ClusterRoleBinding named `secret-reader-binding` to bind the `secret-re
 | **Resources** | NetworkPolicy |
 
 ### Task
+
 Create a NetworkPolicy named `strict-ingress` in the `charge` namespace.
 It should apply to pods with the label `role=db` in the `charge` namespace.
 Allow ingress traffic on TCP port `3306` ONLY if the traffic comes from:
+
 - Pods with the label `role=api` AND
 - The pods must be in a namespace with the label `env=prod`.
 (Ensure you use the correct syntax for AND logic in `from` rules).
@@ -341,6 +369,7 @@ Allow ingress traffic on TCP port `3306` ONLY if the traffic comes from:
 | **Resources** | Ingress |
 
 ### Task
+
 Create an Ingress named `default-ing` in the `surge` namespace.
 Configure it with a `defaultBackend` that routes all unmatched traffic to a service named `fallback-svc` on port `8080`.
 There should be NO host or path rules defined.
@@ -358,6 +387,7 @@ There should be NO host or path rules defined.
 | **Resources** | Service |
 
 ### Task
+
 Create a Service named `sticky-svc` in the `flash` namespace that exposes port `80` and targets TCP port `8080`.
 The selector should be `app=sticky`.
 Configure the service to use `ClientIP` session affinity.
@@ -376,6 +406,7 @@ Set the session affinity timeout to `10800` seconds (3 hours).
 | **Resources** | File |
 
 ### Task
+
 There is a Pod named `hidden-api` running in the `strike` namespace, listening on port `8080`.
 Use port-forwarding to forward local port `9090` to the pod's port `8080`.
 While the port-forward is running, use `curl` to fetch `http://localhost:9090/status`.

--- a/exams/ckad-simulation14/scoring-functions.sh
+++ b/exams/ckad-simulation14/scoring-functions.sh
@@ -7,575 +7,575 @@ source "$SCRIPT_DIR/../../scripts/lib/common.sh" 2>/dev/null || true
 EXAM_DIR="./exam/course/14"
 
 score_q1() {
-  local score=0
-  local max_points=4
-  local details=""
-  local file="${EXAM_DIR}/q1/Dockerfile"
+	local score=0
+	local max_points=4
+	local details=""
+	local file="${EXAM_DIR}/q1/Dockerfile"
 
-  if [ -f "$file" ]; then
-    ((score++))
-    details+="Dockerfile exists. "
-    
-    if grep -q "FROM nginx:1.23-alpine" "$file"; then
-      ((score++))
-      details+="Base image is correct. "
-    fi
-    
-    if grep -q "HEALTHCHECK" "$file" && grep -q "\--interval=10s" "$file" && grep -q "\--timeout=3s" "$file"; then
-      ((score++))
-      details+="HEALTHCHECK timing options correct. "
-    fi
-    
-    if grep -q "curl -f http://localhost/ || exit 1" "$file"; then
-      ((score++))
-      details+="HEALTHCHECK command correct. "
-    fi
-  else
-    details+="Dockerfile not found."
-  fi
+	if [ -f "$file" ]; then
+		((score++))
+		details+="Dockerfile exists. "
 
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+		if grep -q "FROM nginx:1.23-alpine" "$file"; then
+			((score++))
+			details+="Base image is correct. "
+		fi
+
+		if grep -q "HEALTHCHECK" "$file" && grep -q "\--interval=10s" "$file" && grep -q "\--timeout=3s" "$file"; then
+			((score++))
+			details+="HEALTHCHECK timing options correct. "
+		fi
+
+		if grep -q "curl -f http://localhost/ || exit 1" "$file"; then
+			((score++))
+			details+="HEALTHCHECK command correct. "
+		fi
+	else
+		details+="Dockerfile not found."
+	fi
+
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q2() {
-  local score=0
-  local max_points=6
-  local details=""
+	local score=0
+	local max_points=6
+	local details=""
 
-  if resource_exists pod thunder-logger thunder; then
-    ((score+=2))
-    details+="Pod exists. "
-    
-    local init_cnt=$(kubectl get pod thunder-logger -n thunder -o jsonpath='{.spec.containers[*].name}')
-    if [[ "$init_cnt" == *"app-container"* ]] && [[ "$init_cnt" == *"error-tailer"* ]]; then
-      ((score+=2))
-      details+="Containers exist. "
-    fi
-    
-    local vol=$(kubectl get pod thunder-logger -n thunder -o jsonpath='{.spec.volumes[0].emptyDir}')
-    if [[ -n "$vol" ]]; then
-      ((score++))
-      details+="emptyDir volume configured. "
-    fi
-    
-    local cmd=$(kubectl get pod thunder-logger -n thunder -o jsonpath='{.spec.containers[?(@.name=="error-tailer")].command}')
-    if [[ "$cmd" == *"grep"* ]] && [[ "$cmd" == *"ERROR"* ]]; then
-      ((score++))
-      details+="Sidecar tail/grep command present. "
-    fi
-  else
-    details+="Pod thunder-logger not found in thunder namespace."
-  fi
+	if resource_exists pod thunder-logger thunder; then
+		((score += 2))
+		details+="Pod exists. "
 
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+		local init_cnt=$(kubectl get pod thunder-logger -n thunder -o jsonpath='{.spec.containers[*].name}')
+		if [[ "$init_cnt" == *"app-container"* ]] && [[ "$init_cnt" == *"error-tailer"* ]]; then
+			((score += 2))
+			details+="Containers exist. "
+		fi
+
+		local vol=$(kubectl get pod thunder-logger -n thunder -o jsonpath='{.spec.volumes[0].emptyDir}')
+		if [[ -n "$vol" ]]; then
+			((score++))
+			details+="emptyDir volume configured. "
+		fi
+
+		local cmd=$(kubectl get pod thunder-logger -n thunder -o jsonpath='{.spec.containers[?(@.name=="error-tailer")].command}')
+		if [[ "$cmd" == *"grep"* ]] && [[ "$cmd" == *"ERROR"* ]]; then
+			((score++))
+			details+="Sidecar tail/grep command present. "
+		fi
+	else
+		details+="Pod thunder-logger not found in thunder namespace."
+	fi
+
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q3() {
-  local score=0
-  local max_points=6
-  local details=""
+	local score=0
+	local max_points=6
+	local details=""
 
-  if resource_exists cronjob lightning-strike bolt; then
-    ((score+=2))
-    details+="CronJob exists. "
-    
-    local sched=$(kubectl get cronjob lightning-strike -n bolt -o jsonpath='{.spec.schedule}')
-    if [[ "$sched" == *"*/5 * * * *"* ]]; then
-      ((score+=2))
-      details+="Schedule correct. "
-    fi
-    
-    local dls=$(kubectl get cronjob lightning-strike -n bolt -o jsonpath='{.spec.startingDeadlineSeconds}')
-    if [[ "$dls" == "15" ]]; then
-      ((score++))
-      details+="startingDeadlineSeconds correct. "
-    fi
-    
-    local hl=$(kubectl get cronjob lightning-strike -n bolt -o jsonpath='{.spec.successfulJobsHistoryLimit}')
-    if [[ "$hl" == "2" ]]; then
-      ((score++))
-      details+="successfulJobsHistoryLimit correct. "
-    fi
-  else
-    details+="CronJob lightning-strike not found."
-  fi
+	if resource_exists cronjob lightning-strike bolt; then
+		((score += 2))
+		details+="CronJob exists. "
 
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+		local sched=$(kubectl get cronjob lightning-strike -n bolt -o jsonpath='{.spec.schedule}')
+		if [[ "$sched" == *"*/5 * * * *"* ]]; then
+			((score += 2))
+			details+="Schedule correct. "
+		fi
+
+		local dls=$(kubectl get cronjob lightning-strike -n bolt -o jsonpath='{.spec.startingDeadlineSeconds}')
+		if [[ "$dls" == "15" ]]; then
+			((score++))
+			details+="startingDeadlineSeconds correct. "
+		fi
+
+		local hl=$(kubectl get cronjob lightning-strike -n bolt -o jsonpath='{.spec.successfulJobsHistoryLimit}')
+		if [[ "$hl" == "2" ]]; then
+			((score++))
+			details+="successfulJobsHistoryLimit correct. "
+		fi
+	else
+		details+="CronJob lightning-strike not found."
+	fi
+
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q4() {
-  local score=0
-  local max_points=6
-  local details=""
+	local score=0
+	local max_points=6
+	local details=""
 
-  if resource_exists pod app-with-wait storm; then
-    ((score+=2))
-    details+="Pod exists. "
-    
-    local init_name=$(kubectl get pod app-with-wait -n storm -o jsonpath='{.spec.initContainers[0].name}')
-    if [[ "$init_name" == "wait-for-db" ]]; then
-      ((score+=2))
-      details+="Init container exists. "
-      
-      local cmd=$(kubectl get pod app-with-wait -n storm -o jsonpath='{.spec.initContainers[0].command}')
-      if [[ "$cmd" == *"database-svc"* ]]; then
-        ((score+=2))
-        details+="Init container references database-svc. "
-      fi
-    else
-      details+="Init container incorrect. "
-    fi
-  else
-    details+="Pod app-with-wait not found."
-  fi
+	if resource_exists pod app-with-wait storm; then
+		((score += 2))
+		details+="Pod exists. "
 
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+		local init_name=$(kubectl get pod app-with-wait -n storm -o jsonpath='{.spec.initContainers[0].name}')
+		if [[ "$init_name" == "wait-for-db" ]]; then
+			((score += 2))
+			details+="Init container exists. "
+
+			local cmd=$(kubectl get pod app-with-wait -n storm -o jsonpath='{.spec.initContainers[0].command}')
+			if [[ "$cmd" == *"database-svc"* ]]; then
+				((score += 2))
+				details+="Init container references database-svc. "
+			fi
+		else
+			details+="Init container incorrect. "
+		fi
+	else
+		details+="Pod app-with-wait not found."
+	fi
+
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q5() {
-  local score=0
-  local max_points=5
-  local details=""
-  local file="${EXAM_DIR}/q5/output.yaml"
+	local score=0
+	local max_points=5
+	local details=""
+	local file="${EXAM_DIR}/q5/output.yaml"
 
-  if [ -f "$file" ]; then
-    ((score+=2))
-    details+="Output file exists. "
-    
-    if grep -q "replicas: 3" "$file"; then
-      ((score+=1))
-      details+="Replica override successful. "
-    fi
-    
-    if grep -q "image: \"nginx:latest\"" "$file"; then
-      ((score+=2))
-      details+="Image tag override successful. "
-    fi
-  else
-    details+="output.yaml not found."
-  fi
+	if [ -f "$file" ]; then
+		((score += 2))
+		details+="Output file exists. "
 
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+		if grep -q "replicas: 3" "$file"; then
+			((score += 1))
+			details+="Replica override successful. "
+		fi
+
+		if grep -q "image: \"nginx:latest\"" "$file"; then
+			((score += 2))
+			details+="Image tag override successful. "
+		fi
+	else
+		details+="output.yaml not found."
+	fi
+
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q6() {
-  local score=0
-  local max_points=5
-  local details=""
+	local score=0
+	local max_points=5
+	local details=""
 
-  if resource_exists deployment api-gateway voltage; then
-    ((score+=2))
-    details+="Deployment exists. "
-    
-    local img=$(kubectl get deployment api-gateway -n voltage -o jsonpath='{.spec.template.spec.containers[0].image}')
-    if [[ "$img" == "nginx:1.23" ]]; then
-      ((score+=3))
-      details+="Deployment rolled back to revision 1 (nginx:1.23). "
-    else
-      details+="Image is $img, rollback might not be complete. "
-    fi
-  else
-    details+="Deployment api-gateway not found."
-  fi
+	if resource_exists deployment api-gateway voltage; then
+		((score += 2))
+		details+="Deployment exists. "
 
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+		local img=$(kubectl get deployment api-gateway -n voltage -o jsonpath='{.spec.template.spec.containers[0].image}')
+		if [[ "$img" == "nginx:1.23" ]]; then
+			((score += 3))
+			details+="Deployment rolled back to revision 1 (nginx:1.23). "
+		else
+			details+="Image is $img, rollback might not be complete. "
+		fi
+	else
+		details+="Deployment api-gateway not found."
+	fi
+
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q7() {
-  local score=0
-  local max_points=7
-  local details=""
+	local score=0
+	local max_points=7
+	local details=""
 
-  if resource_exists deployment backend-v2 spark; then
-    ((score+=2))
-    details+="Canary deployment exists. "
-    
-    local rep=$(kubectl get deployment backend-v2 -n spark -o jsonpath='{.spec.replicas}')
-    if [[ "$rep" == "1" ]]; then
-      ((score+=2))
-      details+="Replicas is 1. "
-    fi
-    
-    local img=$(kubectl get deployment backend-v2 -n spark -o jsonpath='{.spec.template.spec.containers[0].image}')
-    if [[ "$img" == "nginx:1.23" ]]; then
-      ((score+=1))
-      details+="Image is correct. "
-    fi
-    
-    local labels=$(kubectl get deployment backend-v2 -n spark -o jsonpath='{.spec.template.metadata.labels.app}')
-    if [[ "$labels" == "backend" ]]; then
-      ((score+=2))
-      details+="Labels match service selector. "
-    fi
-  else
-    details+="Canary deployment not found."
-  fi
+	if resource_exists deployment backend-v2 spark; then
+		((score += 2))
+		details+="Canary deployment exists. "
 
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+		local rep=$(kubectl get deployment backend-v2 -n spark -o jsonpath='{.spec.replicas}')
+		if [[ "$rep" == "1" ]]; then
+			((score += 2))
+			details+="Replicas is 1. "
+		fi
+
+		local img=$(kubectl get deployment backend-v2 -n spark -o jsonpath='{.spec.template.spec.containers[0].image}')
+		if [[ "$img" == "nginx:1.23" ]]; then
+			((score += 1))
+			details+="Image is correct. "
+		fi
+
+		local labels=$(kubectl get deployment backend-v2 -n spark -o jsonpath='{.spec.template.metadata.labels.app}')
+		if [[ "$labels" == "backend" ]]; then
+			((score += 2))
+			details+="Labels match service selector. "
+		fi
+	else
+		details+="Canary deployment not found."
+	fi
+
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q8() {
-  local score=0
-  local max_points=6
-  local details=""
+	local score=0
+	local max_points=6
+	local details=""
 
-  if resource_exists deployment api-worker charge; then
-    ((score+=2))
-    details+="Deployment exists in charge namespace. "
-    
-    local env_val=$(kubectl get deployment api-worker -n charge -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="APP_ENV")].value}')
-    if [[ "$env_val" == "production" ]]; then
-      ((score+=4))
-      details+="Strategic merge patch successfully applied APP_ENV. "
-    else
-      details+="APP_ENV not found or incorrect. "
-    fi
-  else
-    details+="Deployment api-worker not found."
-  fi
+	if resource_exists deployment api-worker charge; then
+		((score += 2))
+		details+="Deployment exists in charge namespace. "
 
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+		local env_val=$(kubectl get deployment api-worker -n charge -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="APP_ENV")].value}')
+		if [[ "$env_val" == "production" ]]; then
+			((score += 4))
+			details+="Strategic merge patch successfully applied APP_ENV. "
+		else
+			details+="APP_ENV not found or incorrect. "
+		fi
+	else
+		details+="Deployment api-worker not found."
+	fi
+
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q9() {
-  local score=0
-  local max_points=5
-  local details=""
+	local score=0
+	local max_points=5
+	local details=""
 
-  if resource_exists pod data-processor flash; then
-    local phase=$(kubectl get pod data-processor -n flash -o jsonpath='{.status.phase}')
-    if [[ "$phase" == "Running" ]]; then
-      ((score+=5))
-      details+="Pod is running and fixed. "
-    else
-      details+="Pod is still failing (Phase: $phase). "
-    fi
-  else
-    details+="Pod not found."
-  fi
+	if resource_exists pod data-processor flash; then
+		local phase=$(kubectl get pod data-processor -n flash -o jsonpath='{.status.phase}')
+		if [[ "$phase" == "Running" ]]; then
+			((score += 5))
+			details+="Pod is running and fixed. "
+		else
+			details+="Pod is still failing (Phase: $phase). "
+		fi
+	else
+		details+="Pod not found."
+	fi
 
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q10() {
-  local score=0
-  local max_points=5
-  local details=""
-  local file="${EXAM_DIR}/q10/events.txt"
+	local score=0
+	local max_points=5
+	local details=""
+	local file="${EXAM_DIR}/q10/events.txt"
 
-  if [ -f "$file" ]; then
-    ((score+=3))
-    details+="Events file exists. "
-    
-    if [ -s "$file" ]; then
-      ((score+=2))
-      details+="File is not empty. "
-    fi
-  else
-    details+="events.txt not found."
-  fi
+	if [ -f "$file" ]; then
+		((score += 3))
+		details+="Events file exists. "
 
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+		if [ -s "$file" ]; then
+			((score += 2))
+			details+="File is not empty. "
+		fi
+	else
+		details+="events.txt not found."
+	fi
+
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q11() {
-  local score=0
-  local max_points=7
-  local details=""
+	local score=0
+	local max_points=7
+	local details=""
 
-  if resource_exists pod complex-app plasma; then
-    ((score+=1))
-    details+="Pod exists. "
-    
-    local sp=$(kubectl get pod complex-app -n plasma -o jsonpath='{.spec.containers[0].startupProbe}')
-    if [[ -n "$sp" ]]; then
-      ((score+=2))
-      details+="Startup probe exists. "
-    fi
-    
-    local lp=$(kubectl get pod complex-app -n plasma -o jsonpath='{.spec.containers[0].livenessProbe}')
-    if [[ -n "$lp" ]]; then
-      ((score+=2))
-      details+="Liveness probe exists. "
-    fi
-    
-    local rp=$(kubectl get pod complex-app -n plasma -o jsonpath='{.spec.containers[0].readinessProbe}')
-    if [[ -n "$rp" ]]; then
-      ((score+=2))
-      details+="Readiness probe exists. "
-    fi
-  else
-    details+="Pod complex-app not found."
-  fi
+	if resource_exists pod complex-app plasma; then
+		((score += 1))
+		details+="Pod exists. "
 
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+		local sp=$(kubectl get pod complex-app -n plasma -o jsonpath='{.spec.containers[0].startupProbe}')
+		if [[ -n "$sp" ]]; then
+			((score += 2))
+			details+="Startup probe exists. "
+		fi
+
+		local lp=$(kubectl get pod complex-app -n plasma -o jsonpath='{.spec.containers[0].livenessProbe}')
+		if [[ -n "$lp" ]]; then
+			((score += 2))
+			details+="Liveness probe exists. "
+		fi
+
+		local rp=$(kubectl get pod complex-app -n plasma -o jsonpath='{.spec.containers[0].readinessProbe}')
+		if [[ -n "$rp" ]]; then
+			((score += 2))
+			details+="Readiness probe exists. "
+		fi
+	else
+		details+="Pod complex-app not found."
+	fi
+
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q12() {
-  local score=0
-  local max_points=5
-  local details=""
+	local score=0
+	local max_points=5
+	local details=""
 
-  if resource_exists pod env-info thunder; then
-    ((score+=1))
-    details+="Pod exists. "
-    
-    local p_name=$(kubectl get pod env-info -n thunder -o jsonpath='{.spec.containers[0].env[?(@.name=="POD_NAME")].valueFrom.fieldRef.fieldPath}')
-    if [[ "$p_name" == "metadata.name" ]]; then
-      ((score+=2))
-      details+="POD_NAME mapped correctly. "
-    fi
-    
-    local p_ns=$(kubectl get pod env-info -n thunder -o jsonpath='{.spec.containers[0].env[?(@.name=="POD_NAMESPACE")].valueFrom.fieldRef.fieldPath}')
-    if [[ "$p_ns" == "metadata.namespace" ]]; then
-      ((score+=2))
-      details+="POD_NAMESPACE mapped correctly. "
-    fi
-  else
-    details+="Pod env-info not found."
-  fi
+	if resource_exists pod env-info thunder; then
+		((score += 1))
+		details+="Pod exists. "
 
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+		local p_name=$(kubectl get pod env-info -n thunder -o jsonpath='{.spec.containers[0].env[?(@.name=="POD_NAME")].valueFrom.fieldRef.fieldPath}')
+		if [[ "$p_name" == "metadata.name" ]]; then
+			((score += 2))
+			details+="POD_NAME mapped correctly. "
+		fi
+
+		local p_ns=$(kubectl get pod env-info -n thunder -o jsonpath='{.spec.containers[0].env[?(@.name=="POD_NAMESPACE")].valueFrom.fieldRef.fieldPath}')
+		if [[ "$p_ns" == "metadata.namespace" ]]; then
+			((score += 2))
+			details+="POD_NAMESPACE mapped correctly. "
+		fi
+	else
+		details+="Pod env-info not found."
+	fi
+
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q13() {
-  local score=0
-  local max_points=6
-  local details=""
+	local score=0
+	local max_points=6
+	local details=""
 
-  if resource_exists pod secure-net bolt; then
-    ((score+=2))
-    details+="Pod exists. "
-    
-    local drop=$(kubectl get pod secure-net -n bolt -o jsonpath='{.spec.containers[0].securityContext.capabilities.drop[0]}')
-    if [[ "$drop" == "ALL" ]]; then
-      ((score+=2))
-      details+="Dropped ALL capabilities. "
-    fi
-    
-    local add=$(kubectl get pod secure-net -n bolt -o jsonpath='{.spec.containers[0].securityContext.capabilities.add[0]}')
-    if [[ "$add" == "NET_ADMIN" ]]; then
-      ((score+=2))
-      details+="Added NET_ADMIN capability. "
-    fi
-  else
-    details+="Pod secure-net not found."
-  fi
+	if resource_exists pod secure-net bolt; then
+		((score += 2))
+		details+="Pod exists. "
 
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+		local drop=$(kubectl get pod secure-net -n bolt -o jsonpath='{.spec.containers[0].securityContext.capabilities.drop[0]}')
+		if [[ "$drop" == "ALL" ]]; then
+			((score += 2))
+			details+="Dropped ALL capabilities. "
+		fi
+
+		local add=$(kubectl get pod secure-net -n bolt -o jsonpath='{.spec.containers[0].securityContext.capabilities.add[0]}')
+		if [[ "$add" == "NET_ADMIN" ]]; then
+			((score += 2))
+			details+="Added NET_ADMIN capability. "
+		fi
+	else
+		details+="Pod secure-net not found."
+	fi
+
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q14() {
-  local score=0
-  local max_points=5
-  local details=""
+	local score=0
+	local max_points=5
+	local details=""
 
-  if resource_exists secret db-credentials storm; then
-    ((score+=2))
-    details+="Secret exists. "
-    
-    local user=$(kubectl get secret db-credentials -n storm -o jsonpath='{.data.username}' | base64 -d)
-    if [[ "$user" == "admin" ]]; then
-      ((score+=1))
-      details+="Username correct. "
-    fi
-    
-    local pass=$(kubectl get secret db-credentials -n storm -o jsonpath='{.data.password}' | base64 -d)
-    if [[ "$pass" == "supersecret123" ]]; then
-      ((score+=2))
-      details+="Password correct. "
-    fi
-  else
-    details+="Secret db-credentials not found."
-  fi
+	if resource_exists secret db-credentials storm; then
+		((score += 2))
+		details+="Secret exists. "
 
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+		local user=$(kubectl get secret db-credentials -n storm -o jsonpath='{.data.username}' | base64 -d)
+		if [[ "$user" == "admin" ]]; then
+			((score += 1))
+			details+="Username correct. "
+		fi
+
+		local pass=$(kubectl get secret db-credentials -n storm -o jsonpath='{.data.password}' | base64 -d)
+		if [[ "$pass" == "supersecret123" ]]; then
+			((score += 2))
+			details+="Password correct. "
+		fi
+	else
+		details+="Secret db-credentials not found."
+	fi
+
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q15() {
-  local score=0
-  local max_points=5
-  local details=""
+	local score=0
+	local max_points=5
+	local details=""
 
-  if resource_exists configmap app-args voltage; then
-    ((score+=1))
-    details+="ConfigMap exists. "
-  else
-    details+="ConfigMap app-args not found. "
-  fi
+	if resource_exists configmap app-args voltage; then
+		((score += 1))
+		details+="ConfigMap exists. "
+	else
+		details+="ConfigMap app-args not found. "
+	fi
 
-  if resource_exists pod arg-reader voltage; then
-    ((score+=2))
-    details+="Pod exists. "
-    
-    local args=$(kubectl get pod arg-reader -n voltage -o jsonpath='{.spec.containers[0].args}')
-    if [[ -n "$args" ]]; then
-      ((score+=2))
-      details+="Pod args configured. "
-    fi
-  else
-    details+="Pod arg-reader not found."
-  fi
+	if resource_exists pod arg-reader voltage; then
+		((score += 2))
+		details+="Pod exists. "
 
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+		local args=$(kubectl get pod arg-reader -n voltage -o jsonpath='{.spec.containers[0].args}')
+		if [[ -n "$args" ]]; then
+			((score += 2))
+			details+="Pod args configured. "
+		fi
+	else
+		details+="Pod arg-reader not found."
+	fi
+
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q16() {
-  local score=0
-  local max_points=7
-  local details=""
+	local score=0
+	local max_points=7
+	local details=""
 
-  if resource_exists clusterrole secret-reader; then
-    ((score+=2))
-    details+="ClusterRole exists. "
-    
-    local res=$(kubectl get clusterrole secret-reader -o jsonpath='{.rules[0].resources[0]}')
-    if [[ "$res" == "secrets" ]]; then
-      ((score+=2))
-      details+="Resource is secrets. "
-    fi
-  else
-    details+="ClusterRole not found. "
-  fi
+	if resource_exists clusterrole secret-reader; then
+		((score += 2))
+		details+="ClusterRole exists. "
 
-  if resource_exists clusterrolebinding secret-reader-binding; then
-    ((score+=2))
-    details+="ClusterRoleBinding exists. "
-    
-    local sa=$(kubectl get clusterrolebinding secret-reader-binding -o jsonpath='{.subjects[0].name}')
-    if [[ "$sa" == "app-sa" ]]; then
-      ((score+=1))
-      details+="Bound to app-sa. "
-    fi
-  else
-    details+="ClusterRoleBinding not found."
-  fi
+		local res=$(kubectl get clusterrole secret-reader -o jsonpath='{.rules[0].resources[0]}')
+		if [[ "$res" == "secrets" ]]; then
+			((score += 2))
+			details+="Resource is secrets. "
+		fi
+	else
+		details+="ClusterRole not found. "
+	fi
 
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+	if resource_exists clusterrolebinding secret-reader-binding; then
+		((score += 2))
+		details+="ClusterRoleBinding exists. "
+
+		local sa=$(kubectl get clusterrolebinding secret-reader-binding -o jsonpath='{.subjects[0].name}')
+		if [[ "$sa" == "app-sa" ]]; then
+			((score += 1))
+			details+="Bound to app-sa. "
+		fi
+	else
+		details+="ClusterRoleBinding not found."
+	fi
+
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q17() {
-  local score=0
-  local max_points=6
-  local details=""
+	local score=0
+	local max_points=6
+	local details=""
 
-  if resource_exists networkpolicy strict-ingress charge; then
-    ((score+=2))
-    details+="NetworkPolicy exists. "
-    
-    local ps=$(kubectl get networkpolicy strict-ingress -n charge -o jsonpath='{.spec.podSelector.matchLabels.role}')
-    if [[ "$ps" == "db" ]]; then
-      ((score+=1))
-      details+="Applied to correct pods. "
-    fi
-    
-    local ns_sel=$(kubectl get networkpolicy strict-ingress -n charge -o jsonpath='{.spec.ingress[0].from[0].namespaceSelector.matchLabels.env}')
-    local p_sel=$(kubectl get networkpolicy strict-ingress -n charge -o jsonpath='{.spec.ingress[0].from[0].podSelector.matchLabels.role}')
-    
-    if [[ "$ns_sel" == "prod" ]] && [[ "$p_sel" == "api" ]]; then
-      ((score+=3))
-      details+="AND logic correctly implemented. "
-    else
-      details+="AND logic missing or incorrect. "
-    fi
-  else
-    details+="NetworkPolicy strict-ingress not found."
-  fi
+	if resource_exists networkpolicy strict-ingress charge; then
+		((score += 2))
+		details+="NetworkPolicy exists. "
 
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+		local ps=$(kubectl get networkpolicy strict-ingress -n charge -o jsonpath='{.spec.podSelector.matchLabels.role}')
+		if [[ "$ps" == "db" ]]; then
+			((score += 1))
+			details+="Applied to correct pods. "
+		fi
+
+		local ns_sel=$(kubectl get networkpolicy strict-ingress -n charge -o jsonpath='{.spec.ingress[0].from[0].namespaceSelector.matchLabels.env}')
+		local p_sel=$(kubectl get networkpolicy strict-ingress -n charge -o jsonpath='{.spec.ingress[0].from[0].podSelector.matchLabels.role}')
+
+		if [[ "$ns_sel" == "prod" ]] && [[ "$p_sel" == "api" ]]; then
+			((score += 3))
+			details+="AND logic correctly implemented. "
+		else
+			details+="AND logic missing or incorrect. "
+		fi
+	else
+		details+="NetworkPolicy strict-ingress not found."
+	fi
+
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q18() {
-  local score=0
-  local max_points=5
-  local details=""
+	local score=0
+	local max_points=5
+	local details=""
 
-  if resource_exists ingress default-ing surge; then
-    ((score+=2))
-    details+="Ingress exists. "
-    
-    local svc=$(kubectl get ingress default-ing -n surge -o jsonpath='{.spec.defaultBackend.service.name}')
-    if [[ "$svc" == "fallback-svc" ]]; then
-      ((score+=3))
-      details+="Default backend configured correctly. "
-    else
-      details+="Default backend incorrect. "
-    fi
-  else
-    details+="Ingress default-ing not found."
-  fi
+	if resource_exists ingress default-ing surge; then
+		((score += 2))
+		details+="Ingress exists. "
 
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+		local svc=$(kubectl get ingress default-ing -n surge -o jsonpath='{.spec.defaultBackend.service.name}')
+		if [[ "$svc" == "fallback-svc" ]]; then
+			((score += 3))
+			details+="Default backend configured correctly. "
+		else
+			details+="Default backend incorrect. "
+		fi
+	else
+		details+="Ingress default-ing not found."
+	fi
+
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q19() {
-  local score=0
-  local max_points=5
-  local details=""
+	local score=0
+	local max_points=5
+	local details=""
 
-  if resource_exists service sticky-svc flash; then
-    ((score+=2))
-    details+="Service exists. "
-    
-    local affinity=$(kubectl get service sticky-svc -n flash -o jsonpath='{.spec.sessionAffinity}')
-    if [[ "$affinity" == "ClientIP" ]]; then
-      ((score+=2))
-      details+="ClientIP affinity set. "
-      
-      local timeout=$(kubectl get service sticky-svc -n flash -o jsonpath='{.spec.sessionAffinityConfig.clientIP.timeoutSeconds}')
-      if [[ "$timeout" == "10800" ]]; then
-        ((score+=1))
-        details+="Timeout set correctly. "
-      fi
-    else
-      details+="Session affinity not ClientIP. "
-    fi
-  else
-    details+="Service sticky-svc not found."
-  fi
+	if resource_exists service sticky-svc flash; then
+		((score += 2))
+		details+="Service exists. "
 
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+		local affinity=$(kubectl get service sticky-svc -n flash -o jsonpath='{.spec.sessionAffinity}')
+		if [[ "$affinity" == "ClientIP" ]]; then
+			((score += 2))
+			details+="ClientIP affinity set. "
+
+			local timeout=$(kubectl get service sticky-svc -n flash -o jsonpath='{.spec.sessionAffinityConfig.clientIP.timeoutSeconds}')
+			if [[ "$timeout" == "10800" ]]; then
+				((score += 1))
+				details+="Timeout set correctly. "
+			fi
+		else
+			details+="Session affinity not ClientIP. "
+		fi
+	else
+		details+="Service sticky-svc not found."
+	fi
+
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q20() {
-  local score=0
-  local max_points=6
-  local details=""
-  local file="${EXAM_DIR}/q20/response.txt"
+	local score=0
+	local max_points=6
+	local details=""
+	local file="${EXAM_DIR}/q20/response.txt"
 
-  if [ -f "$file" ]; then
-    ((score+=3))
-    details+="Response file exists. "
-    
-    if grep -iq "method" "$file" || grep -iq "path" "$file" || grep -iq "headers" "$file"; then
-      ((score+=3))
-      details+="Response contains expected output. "
-    else
-      details+="Response content does not look like http-https-echo output. "
-    fi
-  else
-    details+="response.txt not found."
-  fi
+	if [ -f "$file" ]; then
+		((score += 3))
+		details+="Response file exists. "
 
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+		if grep -iq "method" "$file" || grep -iq "path" "$file" || grep -iq "headers" "$file"; then
+			((score += 3))
+			details+="Response contains expected output. "
+		else
+			details+="Response content does not look like http-https-echo output. "
+		fi
+	else
+		details+="response.txt not found."
+	fi
+
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }

--- a/exams/ckad-simulation14/solutions.md
+++ b/exams/ckad-simulation14/solutions.md
@@ -54,7 +54,9 @@ kubectl apply -f ./exam/course/14/q2/pod.yaml
 mkdir -p ./exam/course/14/q3
 kubectl create cronjob lightning-strike -n bolt --image=busybox --schedule="*/5 * * * *" --dry-run=client -o yaml -- echo "Strike!" > ./exam/course/14/q3/cronjob.yaml
 ```
+
 Modify `./exam/course/14/q3/cronjob.yaml` to add `startingDeadlineSeconds` and `successfulJobsHistoryLimit`:
+
 ```yaml
 apiVersion: batch/v1
 kind: CronJob
@@ -77,6 +79,7 @@ spec:
             - "Strike!"
           restartPolicy: OnFailure
 ```
+
 ```bash
 kubectl apply -f ./exam/course/14/q3/cronjob.yaml
 ```
@@ -130,7 +133,9 @@ kubectl rollout undo deployment api-gateway -n voltage --to-revision=1
 mkdir -p ./exam/course/14/q7
 kubectl get deployment backend-v1 -n spark -o yaml > ./exam/course/14/q7/backend-v2.yaml
 ```
+
 Modify `./exam/course/14/q7/backend-v2.yaml` to change name, replicas to 1, and pod template image to `nginx:1.23`. Keep the labels identical so the service matches it.
+
 ```yaml
 apiVersion: apps/v1
 kind: Deployment
@@ -151,6 +156,7 @@ spec:
       - name: nginx
         image: nginx:1.23
 ```
+
 ```bash
 kubectl apply -f ./exam/course/14/q7/backend-v2.yaml
 ```
@@ -192,12 +198,15 @@ kubectl apply -k ./exam/course/14/q8/ -n charge
 ## Question 9 | Kubernetes Practice
 
 Find out why the pod is crashing:
+
 ```bash
 kubectl get pod data-processor -n flash
 kubectl describe pod data-processor -n flash
 kubectl logs data-processor -n flash
 ```
+
 Edit the pod or deployment to fix the error (e.g. correct the command/args or fix the readiness/liveness probe port).
+
 ```bash
 kubectl edit pod data-processor -n flash
 ```

--- a/exams/ckad-simulation15/post-setup.sh
+++ b/exams/ckad-simulation15/post-setup.sh
@@ -1,20 +1,20 @@
 #!/bin/bash
 exam_post_setup() {
-  # Install Helm release for Q5
-  helm repo add bitnami https://charts.bitnami.com/bitnami > /dev/null 2>&1
-  helm repo update > /dev/null 2>&1
-  helm install ocean-api bitnami/nginx --namespace current > /dev/null 2>&1
-  
-  # Generate some warning events for Q10
-  kubectl run failing-pod --image=wrong-image-for-event --namespace depths > /dev/null 2>&1
-  sleep 5
-  kubectl delete pod failing-pod --namespace depths --force --grace-period=0 > /dev/null 2>&1
+	# Install Helm release for Q5
+	helm repo add bitnami https://charts.bitnami.com/bitnami >/dev/null 2>&1
+	helm repo update >/dev/null 2>&1
+	helm install ocean-api bitnami/nginx --namespace current >/dev/null 2>&1
 
-  # === Auto-generated starter files ===
-  local BASE_DIR="./exam/course/15"
-  
-  mkdir -p "$BASE_DIR/q1"
-  cat << 'EOF_FILE' > "$BASE_DIR/q1/Dockerfile"
+	# Generate some warning events for Q10
+	kubectl run failing-pod --image=wrong-image-for-event --namespace depths >/dev/null 2>&1
+	sleep 5
+	kubectl delete pod failing-pod --namespace depths --force --grace-period=0 >/dev/null 2>&1
+
+	# === Auto-generated starter files ===
+	local BASE_DIR="./exam/course/15"
+
+	mkdir -p "$BASE_DIR/q1"
+	cat <<'EOF_FILE' >"$BASE_DIR/q1/Dockerfile"
 FROM golang:1.20-alpine
 COPY . /app
 WORKDIR /app
@@ -22,12 +22,12 @@ RUN go build -o app main.go
 CMD ["./app"]
 EOF_FILE
 
-  mkdir -p "$BASE_DIR/q10"
-  
-  mkdir -p "$BASE_DIR/q12/config-files"
-  echo "key1=value1" > "$BASE_DIR/q12/config-files/app.conf"
-  
-  mkdir -p "$BASE_DIR/q8"
-  
-  return 0
+	mkdir -p "$BASE_DIR/q10"
+
+	mkdir -p "$BASE_DIR/q12/config-files"
+	echo "key1=value1" >"$BASE_DIR/q12/config-files/app.conf"
+
+	mkdir -p "$BASE_DIR/q8"
+
+	return 0
 }

--- a/exams/ckad-simulation15/questions.md
+++ b/exams/ckad-simulation15/questions.md
@@ -29,6 +29,7 @@
 There is a `Dockerfile` located at `./exam/course/15/q1/Dockerfile` that builds a simple Go application. Currently, it uses a single-stage build resulting in a large image.
 
 Modify the `Dockerfile` to use a multi-stage build to reduce the final image size:
+
 1. Use `golang:1.20-alpine` as the builder stage and name the stage `builder`.
 2. Build the go application with `go build -o app main.go` inside the builder stage.
 3. Use `alpine:3.18` as the final image stage.

--- a/exams/ckad-simulation15/scoring-functions.sh
+++ b/exams/ckad-simulation15/scoring-functions.sh
@@ -6,604 +6,604 @@ source "$SCRIPT_DIR/../../scripts/lib/common.sh" 2>/dev/null || true
 
 # Q1: 5 points
 score_q1() {
-  local score=0
-  local max_points=5
-  local details=""
-  
-  if [ -f "./exam/course/15/q1/Dockerfile" ]; then
-    if grep -q "AS builder" "./exam/course/15/q1/Dockerfile" || grep -q "as builder" "./exam/course/15/q1/Dockerfile"; then
-      score=$((score + 2))
-      details+="Builder stage used. "
-    else
-      details+="Builder stage not found. "
-    fi
-    
-    if grep -q "COPY --from=builder" "./exam/course/15/q1/Dockerfile"; then
-      score=$((score + 3))
-      details+="Copy from builder used. "
-    else
-      details+="Copy from builder not found. "
-    fi
-  else
-    details+="Dockerfile not found. "
-  fi
-  
-  echo "$score/$max_points"
-  echo "DETAILS: $details"
+	local score=0
+	local max_points=5
+	local details=""
+
+	if [ -f "./exam/course/15/q1/Dockerfile" ]; then
+		if grep -q "AS builder" "./exam/course/15/q1/Dockerfile" || grep -q "as builder" "./exam/course/15/q1/Dockerfile"; then
+			score=$((score + 2))
+			details+="Builder stage used. "
+		else
+			details+="Builder stage not found. "
+		fi
+
+		if grep -q "COPY --from=builder" "./exam/course/15/q1/Dockerfile"; then
+			score=$((score + 3))
+			details+="Copy from builder used. "
+		else
+			details+="Copy from builder not found. "
+		fi
+	else
+		details+="Dockerfile not found. "
+	fi
+
+	echo "$score/$max_points"
+	echo "DETAILS: $details"
 }
 
 # Q2: 6 points
 score_q2() {
-  local score=0
-  local max_points=6
-  local details=""
-  local ns="tide"
-  local pod="log-generator"
-  
-  if resource_exists pod $pod $ns; then
-    score=$((score + 2))
-    details+="Pod $pod exists. "
-    
-    local c_count=$(kubectl get pod $pod -n $ns -o jsonpath='{range .spec.containers[*]}{.name}{" "}{end}' | wc -w)
-    if [ "$c_count" -ge 2 ]; then
-      score=$((score + 2))
-      details+="Pod has $c_count containers. "
-    else
-      details+="Pod does not have sidecar. "
-    fi
-    
-    local vol=$(kubectl get pod $pod -n $ns -o jsonpath='{.spec.volumes[?(@.name=="shared-logs")].emptyDir}')
-    if [ -n "$vol" ]; then
-      score=$((score + 2))
-      details+="Shared emptyDir volume exists. "
-    else
-      details+="Shared volume not found. "
-    fi
-  else
-    details+="Pod $pod not found. "
-  fi
-  
-  echo "$score/$max_points"
-  echo "DETAILS: $details"
+	local score=0
+	local max_points=6
+	local details=""
+	local ns="tide"
+	local pod="log-generator"
+
+	if resource_exists pod $pod $ns; then
+		score=$((score + 2))
+		details+="Pod $pod exists. "
+
+		local c_count=$(kubectl get pod $pod -n $ns -o jsonpath='{range .spec.containers[*]}{.name}{" "}{end}' | wc -w)
+		if [ "$c_count" -ge 2 ]; then
+			score=$((score + 2))
+			details+="Pod has $c_count containers. "
+		else
+			details+="Pod does not have sidecar. "
+		fi
+
+		local vol=$(kubectl get pod $pod -n $ns -o jsonpath='{.spec.volumes[?(@.name=="shared-logs")].emptyDir}')
+		if [ -n "$vol" ]; then
+			score=$((score + 2))
+			details+="Shared emptyDir volume exists. "
+		else
+			details+="Shared volume not found. "
+		fi
+	else
+		details+="Pod $pod not found. "
+	fi
+
+	echo "$score/$max_points"
+	echo "DETAILS: $details"
 }
 
 # Q3: 5 points
 score_q3() {
-  local score=0
-  local max_points=5
-  local details=""
-  local ns="coral"
-  local cj="data-sync"
-  
-  if resource_exists cronjob $cj $ns; then
-    score=$((score + 1))
-    details+="CronJob $cj exists. "
-    
-    local sched=$(kubectl get cj $cj -n $ns -o jsonpath='{.spec.schedule}')
-    if [[ "$sched" == "*/10 * * * *" ]]; then
-      score=$((score + 1))
-      details+="Schedule correct. "
-    else
-      details+="Schedule incorrect ($sched). "
-    fi
-    
-    local limit=$(kubectl get cj $cj -n $ns -o jsonpath='{.spec.failedJobsHistoryLimit}')
-    if [[ "$limit" == "5" ]]; then
-      score=$((score + 2))
-      details+="History limit correct. "
-    else
-      details+="History limit incorrect ($limit). "
-    fi
-    
-    local suspend=$(kubectl get cj $cj -n $ns -o jsonpath='{.spec.suspend}')
-    if [[ "$suspend" == "true" ]]; then
-      score=$((score + 1))
-      details+="Suspend is true. "
-    else
-      details+="Suspend not true. "
-    fi
-  else
-    details+="CronJob $cj not found. "
-  fi
-  
-  echo "$score/$max_points"
-  echo "DETAILS: $details"
+	local score=0
+	local max_points=5
+	local details=""
+	local ns="coral"
+	local cj="data-sync"
+
+	if resource_exists cronjob $cj $ns; then
+		score=$((score + 1))
+		details+="CronJob $cj exists. "
+
+		local sched=$(kubectl get cj $cj -n $ns -o jsonpath='{.spec.schedule}')
+		if [[ "$sched" == "*/10 * * * *" ]]; then
+			score=$((score + 1))
+			details+="Schedule correct. "
+		else
+			details+="Schedule incorrect ($sched). "
+		fi
+
+		local limit=$(kubectl get cj $cj -n $ns -o jsonpath='{.spec.failedJobsHistoryLimit}')
+		if [[ "$limit" == "5" ]]; then
+			score=$((score + 2))
+			details+="History limit correct. "
+		else
+			details+="History limit incorrect ($limit). "
+		fi
+
+		local suspend=$(kubectl get cj $cj -n $ns -o jsonpath='{.spec.suspend}')
+		if [[ "$suspend" == "true" ]]; then
+			score=$((score + 1))
+			details+="Suspend is true. "
+		else
+			details+="Suspend not true. "
+		fi
+	else
+		details+="CronJob $cj not found. "
+	fi
+
+	echo "$score/$max_points"
+	echo "DETAILS: $details"
 }
 
 # Q4: 6 points
 score_q4() {
-  local score=0
-  local max_points=6
-  local details=""
-  local ns="abyss"
-  local pod="batch-worker"
-  
-  if resource_exists pod $pod $ns; then
-    score=$((score + 3))
-    details+="Pod $pod exists. "
-    
-    local rp=$(kubectl get pod $pod -n $ns -o jsonpath='{.spec.restartPolicy}')
-    if [[ "$rp" == "OnFailure" ]]; then
-      score=$((score + 3))
-      details+="Restart policy is OnFailure. "
-    else
-      details+="Restart policy incorrect ($rp). "
-    fi
-  else
-    details+="Pod $pod not found. "
-  fi
-  
-  echo "$score/$max_points"
-  echo "DETAILS: $details"
+	local score=0
+	local max_points=6
+	local details=""
+	local ns="abyss"
+	local pod="batch-worker"
+
+	if resource_exists pod $pod $ns; then
+		score=$((score + 3))
+		details+="Pod $pod exists. "
+
+		local rp=$(kubectl get pod $pod -n $ns -o jsonpath='{.spec.restartPolicy}')
+		if [[ "$rp" == "OnFailure" ]]; then
+			score=$((score + 3))
+			details+="Restart policy is OnFailure. "
+		else
+			details+="Restart policy incorrect ($rp). "
+		fi
+	else
+		details+="Pod $pod not found. "
+	fi
+
+	echo "$score/$max_points"
+	echo "DETAILS: $details"
 }
 
 # Q5: 4 points
 score_q5() {
-  local score=0
-  local max_points=4
-  local details=""
-  
-  local hr=$(helm list -n current --short | grep ocean-api || echo "")
-  if [ -z "$hr" ]; then
-    score=$((score + 4))
-    details+="Helm release ocean-api uninstalled. "
-  else
-    details+="Helm release ocean-api still exists. "
-  fi
-  
-  echo "$score/$max_points"
-  echo "DETAILS: $details"
+	local score=0
+	local max_points=4
+	local details=""
+
+	local hr=$(helm list -n current --short | grep ocean-api || echo "")
+	if [ -z "$hr" ]; then
+		score=$((score + 4))
+		details+="Helm release ocean-api uninstalled. "
+	else
+		details+="Helm release ocean-api still exists. "
+	fi
+
+	echo "$score/$max_points"
+	echo "DETAILS: $details"
 }
 
 # Q6: 6 points
 score_q6() {
-  local score=0
-  local max_points=6
-  local details=""
-  local ns="reef"
-  local dep="web-deploy"
-  
-  if resource_exists deploy $dep $ns; then
-    score=$((score + 2))
-    details+="Deploy $dep exists. "
-    
-    local surge=$(kubectl get deploy $dep -n $ns -o jsonpath='{.spec.strategy.rollingUpdate.maxSurge}')
-    local unavail=$(kubectl get deploy $dep -n $ns -o jsonpath='{.spec.strategy.rollingUpdate.maxUnavailable}')
-    
-    if [[ "$surge" == "50%" || "$surge" == "2" ]]; then
-      score=$((score + 2))
-      details+="MaxSurge correct. "
-    else
-      details+="MaxSurge incorrect ($surge). "
-    fi
-    
-    if [[ "$unavail" == "25%" || "$unavail" == "1" ]]; then
-      score=$((score + 2))
-      details+="MaxUnavailable correct. "
-    else
-      details+="MaxUnavailable incorrect ($unavail). "
-    fi
-  else
-    details+="Deploy $dep not found. "
-  fi
-  
-  echo "$score/$max_points"
-  echo "DETAILS: $details"
+	local score=0
+	local max_points=6
+	local details=""
+	local ns="reef"
+	local dep="web-deploy"
+
+	if resource_exists deploy $dep $ns; then
+		score=$((score + 2))
+		details+="Deploy $dep exists. "
+
+		local surge=$(kubectl get deploy $dep -n $ns -o jsonpath='{.spec.strategy.rollingUpdate.maxSurge}')
+		local unavail=$(kubectl get deploy $dep -n $ns -o jsonpath='{.spec.strategy.rollingUpdate.maxUnavailable}')
+
+		if [[ "$surge" == "50%" || "$surge" == "2" ]]; then
+			score=$((score + 2))
+			details+="MaxSurge correct. "
+		else
+			details+="MaxSurge incorrect ($surge). "
+		fi
+
+		if [[ "$unavail" == "25%" || "$unavail" == "1" ]]; then
+			score=$((score + 2))
+			details+="MaxUnavailable correct. "
+		else
+			details+="MaxUnavailable incorrect ($unavail). "
+		fi
+	else
+		details+="Deploy $dep not found. "
+	fi
+
+	echo "$score/$max_points"
+	echo "DETAILS: $details"
 }
 
 # Q7: 5 points
 score_q7() {
-  local score=0
-  local max_points=5
-  local details=""
-  local ns="lagoon"
-  local dep="api-server"
-  
-  if resource_exists deploy $dep $ns; then
-    local img=$(kubectl get deploy $dep -n $ns -o jsonpath='{.spec.template.spec.containers[0].image}')
-    if [[ "$img" == "nginx:1.24" ]]; then
-      score=$((score + 5))
-      details+="Deployment rolled back to nginx:1.24. "
-    else
-      details+="Image is $img, expected nginx:1.24. "
-    fi
-  else
-    details+="Deploy $dep not found. "
-  fi
-  
-  echo "$score/$max_points"
-  echo "DETAILS: $details"
+	local score=0
+	local max_points=5
+	local details=""
+	local ns="lagoon"
+	local dep="api-server"
+
+	if resource_exists deploy $dep $ns; then
+		local img=$(kubectl get deploy $dep -n $ns -o jsonpath='{.spec.template.spec.containers[0].image}')
+		if [[ "$img" == "nginx:1.24" ]]; then
+			score=$((score + 5))
+			details+="Deployment rolled back to nginx:1.24. "
+		else
+			details+="Image is $img, expected nginx:1.24. "
+		fi
+	else
+		details+="Deploy $dep not found. "
+	fi
+
+	echo "$score/$max_points"
+	echo "DETAILS: $details"
 }
 
 # Q8: 7 points
 score_q8() {
-  local score=0
-  local max_points=7
-  local details=""
-  local ns="trench"
-  
-  if resource_exists deploy app-deploy $ns; then
-    score=$((score + 2))
-    details+="Deploy app-deploy created via kustomize. "
-    
-    local l_env=$(kubectl get deploy app-deploy -n $ns -o jsonpath='{.metadata.labels.env}')
-    if [[ "$l_env" == "production" ]]; then
-      score=$((score + 2))
-      details+="Label env=production applied. "
-    else
-      details+="Label env incorrect. "
-    fi
-    
-    local a_rel=$(kubectl get deploy app-deploy -n $ns -o jsonpath='{.metadata.annotations.release}')
-    if [[ "$a_rel" == "v1.0.0" ]]; then
-      score=$((score + 2))
-      details+="Annotation release=v1.0.0 applied. "
-    else
-      details+="Annotation release incorrect. "
-    fi
-  else
-    details+="Deploy app-deploy not found. "
-  fi
-  
-  if resource_exists svc app-svc $ns; then
-    score=$((score + 1))
-    details+="Service app-svc created via kustomize. "
-  fi
-  
-  echo "$score/$max_points"
-  echo "DETAILS: $details"
+	local score=0
+	local max_points=7
+	local details=""
+	local ns="trench"
+
+	if resource_exists deploy app-deploy $ns; then
+		score=$((score + 2))
+		details+="Deploy app-deploy created via kustomize. "
+
+		local l_env=$(kubectl get deploy app-deploy -n $ns -o jsonpath='{.metadata.labels.env}')
+		if [[ "$l_env" == "production" ]]; then
+			score=$((score + 2))
+			details+="Label env=production applied. "
+		else
+			details+="Label env incorrect. "
+		fi
+
+		local a_rel=$(kubectl get deploy app-deploy -n $ns -o jsonpath='{.metadata.annotations.release}')
+		if [[ "$a_rel" == "v1.0.0" ]]; then
+			score=$((score + 2))
+			details+="Annotation release=v1.0.0 applied. "
+		else
+			details+="Annotation release incorrect. "
+		fi
+	else
+		details+="Deploy app-deploy not found. "
+	fi
+
+	if resource_exists svc app-svc $ns; then
+		score=$((score + 1))
+		details+="Service app-svc created via kustomize. "
+	fi
+
+	echo "$score/$max_points"
+	echo "DETAILS: $details"
 }
 
 # Q9: 5 points
 score_q9() {
-  local score=0
-  local max_points=5
-  local details=""
-  local ns="wave"
-  local pod="backend-pod"
-  
-  if resource_exists pod $pod $ns; then
-    local img=$(kubectl get pod $pod -n $ns -o jsonpath='{.spec.containers[0].image}')
-    if [[ "$img" == "nginx:alpine" ]]; then
-      score=$((score + 3))
-      details+="Image corrected. "
-      
-      local state=$(kubectl get pod $pod -n $ns -o jsonpath='{.status.phase}')
-      if [[ "$state" == "Running" || "$state" == "Pending" ]]; then
-        score=$((score + 2))
-        details+="Pod not in ErrImagePull. "
-      fi
-    else
-      details+="Image is still $img. "
-    fi
-  else
-    details+="Pod $pod not found. "
-  fi
-  
-  echo "$score/$max_points"
-  echo "DETAILS: $details"
+	local score=0
+	local max_points=5
+	local details=""
+	local ns="wave"
+	local pod="backend-pod"
+
+	if resource_exists pod $pod $ns; then
+		local img=$(kubectl get pod $pod -n $ns -o jsonpath='{.spec.containers[0].image}')
+		if [[ "$img" == "nginx:alpine" ]]; then
+			score=$((score + 3))
+			details+="Image corrected. "
+
+			local state=$(kubectl get pod $pod -n $ns -o jsonpath='{.status.phase}')
+			if [[ "$state" == "Running" || "$state" == "Pending" ]]; then
+				score=$((score + 2))
+				details+="Pod not in ErrImagePull. "
+			fi
+		else
+			details+="Image is still $img. "
+		fi
+	else
+		details+="Pod $pod not found. "
+	fi
+
+	echo "$score/$max_points"
+	echo "DETAILS: $details"
 }
 
 # Q10: 5 points
 score_q10() {
-  local score=0
-  local max_points=5
-  local details=""
-  
-  if [ -s "./exam/course/15/q10/events.txt" ]; then
-    score=$((score + 3))
-    details+="File events.txt exists. "
-    if grep -q "Warning" "./exam/course/15/q10/events.txt"; then
-      score=$((score + 2))
-      details+="Warning events found in file. "
-    else
-      details+="No Warning text found in file. "
-    fi
-  else
-    details+="File events.txt not found. "
-  fi
-  
-  echo "$score/$max_points"
-  echo "DETAILS: $details"
+	local score=0
+	local max_points=5
+	local details=""
+
+	if [ -s "./exam/course/15/q10/events.txt" ]; then
+		score=$((score + 3))
+		details+="File events.txt exists. "
+		if grep -q "Warning" "./exam/course/15/q10/events.txt"; then
+			score=$((score + 2))
+			details+="Warning events found in file. "
+		else
+			details+="No Warning text found in file. "
+		fi
+	else
+		details+="File events.txt not found. "
+	fi
+
+	echo "$score/$max_points"
+	echo "DETAILS: $details"
 }
 
 # Q11: 6 points
 score_q11() {
-  local score=0
-  local max_points=6
-  local details=""
-  local ns="ocean"
-  local pod="grpc-checker"
-  
-  if resource_exists pod $pod $ns; then
-    score=$((score + 2))
-    details+="Pod $pod exists. "
-    
-    local grpc_port=$(kubectl get pod $pod -n $ns -o jsonpath='{.spec.containers[0].livenessProbe.grpc.port}')
-    if [[ "$grpc_port" == "8080" ]]; then
-      score=$((score + 4))
-      details+="gRPC probe configured on port 8080. "
-    else
-      details+="gRPC probe missing or incorrect. "
-    fi
-  else
-    details+="Pod $pod not found. "
-  fi
-  
-  echo "$score/$max_points"
-  echo "DETAILS: $details"
+	local score=0
+	local max_points=6
+	local details=""
+	local ns="ocean"
+	local pod="grpc-checker"
+
+	if resource_exists pod $pod $ns; then
+		score=$((score + 2))
+		details+="Pod $pod exists. "
+
+		local grpc_port=$(kubectl get pod $pod -n $ns -o jsonpath='{.spec.containers[0].livenessProbe.grpc.port}')
+		if [[ "$grpc_port" == "8080" ]]; then
+			score=$((score + 4))
+			details+="gRPC probe configured on port 8080. "
+		else
+			details+="gRPC probe missing or incorrect. "
+		fi
+	else
+		details+="Pod $pod not found. "
+	fi
+
+	echo "$score/$max_points"
+	echo "DETAILS: $details"
 }
 
 # Q12: 5 points
 score_q12() {
-  local score=0
-  local max_points=5
-  local details=""
-  local ns="tide"
-  local cm="app-config-dir"
-  local pod="config-consumer"
-  
-  if resource_exists cm $cm $ns; then
-    score=$((score + 2))
-    details+="ConfigMap $cm exists. "
-  else
-    details+="ConfigMap $cm not found. "
-  fi
-  
-  if resource_exists pod $pod $ns; then
-    local mnt=$(kubectl get pod $pod -n $ns -o jsonpath='{.spec.containers[0].volumeMounts[?(@.name=="config-vol")].mountPath}')
-    # name might not be exactly config-vol, check just mountPath
-    local any_mnt=$(kubectl get pod $pod -n $ns -o jsonpath='{.spec.containers[0].volumeMounts[*].mountPath}')
-    if echo "$any_mnt" | grep -q "/etc/config"; then
-      score=$((score + 3))
-      details+="ConfigMap mounted to /etc/config. "
-    else
-      details+="Mount path /etc/config not found. "
-    fi
-  else
-    details+="Pod $pod not found. "
-  fi
-  
-  echo "$score/$max_points"
-  echo "DETAILS: $details"
+	local score=0
+	local max_points=5
+	local details=""
+	local ns="tide"
+	local cm="app-config-dir"
+	local pod="config-consumer"
+
+	if resource_exists cm $cm $ns; then
+		score=$((score + 2))
+		details+="ConfigMap $cm exists. "
+	else
+		details+="ConfigMap $cm not found. "
+	fi
+
+	if resource_exists pod $pod $ns; then
+		local mnt=$(kubectl get pod $pod -n $ns -o jsonpath='{.spec.containers[0].volumeMounts[?(@.name=="config-vol")].mountPath}')
+		# name might not be exactly config-vol, check just mountPath
+		local any_mnt=$(kubectl get pod $pod -n $ns -o jsonpath='{.spec.containers[0].volumeMounts[*].mountPath}')
+		if echo "$any_mnt" | grep -q "/etc/config"; then
+			score=$((score + 3))
+			details+="ConfigMap mounted to /etc/config. "
+		else
+			details+="Mount path /etc/config not found. "
+		fi
+	else
+		details+="Pod $pod not found. "
+	fi
+
+	echo "$score/$max_points"
+	echo "DETAILS: $details"
 }
 
 # Q13: 5 points
 score_q13() {
-  local score=0
-  local max_points=5
-  local details=""
-  local ns="coral"
-  local sec="db-credentials"
-  local pod="secret-env-pod"
-  
-  if resource_exists secret $sec $ns; then
-    score=$((score + 2))
-    details+="Secret $sec exists. "
-  else
-    details+="Secret $sec not found. "
-  fi
-  
-  if resource_exists pod $pod $ns; then
-    local env1=$(kubectl get pod $pod -n $ns -o jsonpath='{.spec.containers[0].env[?(@.name=="DB_USER")].valueFrom.secretKeyRef.key}')
-    local env2=$(kubectl get pod $pod -n $ns -o jsonpath='{.spec.containers[0].env[?(@.name=="DB_PASS")].valueFrom.secretKeyRef.key}')
-    
-    if [[ "$env1" == "username" && "$env2" == "password" ]]; then
-      score=$((score + 3))
-      details+="Environment variables configured correctly. "
-    else
-      details+="Environment variables incorrect. "
-    fi
-  else
-    details+="Pod $pod not found. "
-  fi
-  
-  echo "$score/$max_points"
-  echo "DETAILS: $details"
+	local score=0
+	local max_points=5
+	local details=""
+	local ns="coral"
+	local sec="db-credentials"
+	local pod="secret-env-pod"
+
+	if resource_exists secret $sec $ns; then
+		score=$((score + 2))
+		details+="Secret $sec exists. "
+	else
+		details+="Secret $sec not found. "
+	fi
+
+	if resource_exists pod $pod $ns; then
+		local env1=$(kubectl get pod $pod -n $ns -o jsonpath='{.spec.containers[0].env[?(@.name=="DB_USER")].valueFrom.secretKeyRef.key}')
+		local env2=$(kubectl get pod $pod -n $ns -o jsonpath='{.spec.containers[0].env[?(@.name=="DB_PASS")].valueFrom.secretKeyRef.key}')
+
+		if [[ "$env1" == "username" && "$env2" == "password" ]]; then
+			score=$((score + 3))
+			details+="Environment variables configured correctly. "
+		else
+			details+="Environment variables incorrect. "
+		fi
+	else
+		details+="Pod $pod not found. "
+	fi
+
+	echo "$score/$max_points"
+	echo "DETAILS: $details"
 }
 
 # Q14: 7 points
 score_q14() {
-  local score=0
-  local max_points=7
-  local details=""
-  local ns="abyss"
-  local pod="secure-pod"
-  local pol="secure-policy"
-  
-  if resource_exists pod $pod $ns; then
-    local uid=$(kubectl get pod $pod -n $ns -o jsonpath='{.spec.securityContext.runAsUser}')
-    local esc=$(kubectl get pod $pod -n $ns -o jsonpath='{.spec.containers[0].securityContext.allowPrivilegeEscalation}')
-    
-    if [[ "$uid" == "1000" ]]; then
-      score=$((score + 2))
-      details+="runAsUser correct. "
-    fi
-    if [[ "$esc" == "false" ]]; then
-      score=$((score + 2))
-      details+="allowPrivilegeEscalation false. "
-    fi
-  else
-    details+="Pod $pod not found. "
-  fi
-  
-  if resource_exists netpol $pol $ns; then
-    score=$((score + 3))
-    details+="NetworkPolicy $pol exists. "
-  else
-    details+="NetworkPolicy not found. "
-  fi
-  
-  echo "$score/$max_points"
-  echo "DETAILS: $details"
+	local score=0
+	local max_points=7
+	local details=""
+	local ns="abyss"
+	local pod="secure-pod"
+	local pol="secure-policy"
+
+	if resource_exists pod $pod $ns; then
+		local uid=$(kubectl get pod $pod -n $ns -o jsonpath='{.spec.securityContext.runAsUser}')
+		local esc=$(kubectl get pod $pod -n $ns -o jsonpath='{.spec.containers[0].securityContext.allowPrivilegeEscalation}')
+
+		if [[ "$uid" == "1000" ]]; then
+			score=$((score + 2))
+			details+="runAsUser correct. "
+		fi
+		if [[ "$esc" == "false" ]]; then
+			score=$((score + 2))
+			details+="allowPrivilegeEscalation false. "
+		fi
+	else
+		details+="Pod $pod not found. "
+	fi
+
+	if resource_exists netpol $pol $ns; then
+		score=$((score + 3))
+		details+="NetworkPolicy $pol exists. "
+	else
+		details+="NetworkPolicy not found. "
+	fi
+
+	echo "$score/$max_points"
+	echo "DETAILS: $details"
 }
 
 # Q15: 5 points
 score_q15() {
-  local score=0
-  local max_points=5
-  local details=""
-  local ns="reef"
-  local pod="target-pod"
-  
-  if resource_exists pod $pod $ns; then
-    local eph=$(kubectl get pod $pod -n $ns -o jsonpath='{.spec.ephemeralContainers[0].name}')
-    if [ -n "$eph" ]; then
-      score=$((score + 5))
-      details+="Ephemeral container '$eph' attached. "
-    else
-      details+="No ephemeral containers found. "
-    fi
-  else
-    details+="Pod $pod not found. "
-  fi
-  
-  echo "$score/$max_points"
-  echo "DETAILS: $details"
+	local score=0
+	local max_points=5
+	local details=""
+	local ns="reef"
+	local pod="target-pod"
+
+	if resource_exists pod $pod $ns; then
+		local eph=$(kubectl get pod $pod -n $ns -o jsonpath='{.spec.ephemeralContainers[0].name}')
+		if [ -n "$eph" ]; then
+			score=$((score + 5))
+			details+="Ephemeral container '$eph' attached. "
+		else
+			details+="No ephemeral containers found. "
+		fi
+	else
+		details+="Pod $pod not found. "
+	fi
+
+	echo "$score/$max_points"
+	echo "DETAILS: $details"
 }
 
 # Q16: 6 points
 score_q16() {
-  local score=0
-  local max_points=6
-  local details=""
-  local ns="lagoon"
-  local dep="critical-app"
-  local pdb="critical-pdb"
-  
-  if resource_exists deploy $dep $ns; then
-    score=$((score + 2))
-    details+="Deploy $dep exists. "
-  else
-    details+="Deploy $dep not found. "
-  fi
-  
-  if resource_exists pdb $pdb $ns; then
-    score=$((score + 2))
-    details+="PDB $pdb exists. "
-    
-    local min=$(kubectl get pdb $pdb -n $ns -o jsonpath='{.spec.minAvailable}')
-    if [[ "$min" == "2" ]]; then
-      score=$((score + 2))
-      details+="minAvailable is 2. "
-    else
-      details+="minAvailable incorrect. "
-    fi
-  else
-    details+="PDB $pdb not found. "
-  fi
-  
-  echo "$score/$max_points"
-  echo "DETAILS: $details"
+	local score=0
+	local max_points=6
+	local details=""
+	local ns="lagoon"
+	local dep="critical-app"
+	local pdb="critical-pdb"
+
+	if resource_exists deploy $dep $ns; then
+		score=$((score + 2))
+		details+="Deploy $dep exists. "
+	else
+		details+="Deploy $dep not found. "
+	fi
+
+	if resource_exists pdb $pdb $ns; then
+		score=$((score + 2))
+		details+="PDB $pdb exists. "
+
+		local min=$(kubectl get pdb $pdb -n $ns -o jsonpath='{.spec.minAvailable}')
+		if [[ "$min" == "2" ]]; then
+			score=$((score + 2))
+			details+="minAvailable is 2. "
+		else
+			details+="minAvailable incorrect. "
+		fi
+	else
+		details+="PDB $pdb not found. "
+	fi
+
+	echo "$score/$max_points"
+	echo "DETAILS: $details"
 }
 
 # Q17: 6 points
 score_q17() {
-  local score=0
-  local max_points=6
-  local details=""
-  local ns="trench"
-  
-  if resource_exists netpol deny-all $ns; then
-    score=$((score + 3))
-    details+="Policy deny-all exists. "
-  else
-    details+="Policy deny-all not found. "
-  fi
-  
-  if resource_exists netpol allow-web $ns; then
-    score=$((score + 3))
-    details+="Policy allow-web exists. "
-  else
-    details+="Policy allow-web not found. "
-  fi
-  
-  echo "$score/$max_points"
-  echo "DETAILS: $details"
+	local score=0
+	local max_points=6
+	local details=""
+	local ns="trench"
+
+	if resource_exists netpol deny-all $ns; then
+		score=$((score + 3))
+		details+="Policy deny-all exists. "
+	else
+		details+="Policy deny-all not found. "
+	fi
+
+	if resource_exists netpol allow-web $ns; then
+		score=$((score + 3))
+		details+="Policy allow-web exists. "
+	else
+		details+="Policy allow-web not found. "
+	fi
+
+	echo "$score/$max_points"
+	echo "DETAILS: $details"
 }
 
 # Q18: 5 points
 score_q18() {
-  local score=0
-  local max_points=5
-  local details=""
-  local ns="wave"
-  local svc="mesh-service"
-  
-  if resource_exists svc $svc $ns; then
-    local ep=$(kubectl get endpoints $svc -n $ns -o jsonpath='{.subsets[0].addresses[0].ip}')
-    if [ -n "$ep" ]; then
-      score=$((score + 5))
-      details+="Service $svc has active endpoints. "
-    else
-      details+="Service $svc has no endpoints. "
-    fi
-  else
-    details+="Service $svc not found. "
-  fi
-  
-  echo "$score/$max_points"
-  echo "DETAILS: $details"
+	local score=0
+	local max_points=5
+	local details=""
+	local ns="wave"
+	local svc="mesh-service"
+
+	if resource_exists svc $svc $ns; then
+		local ep=$(kubectl get endpoints $svc -n $ns -o jsonpath='{.subsets[0].addresses[0].ip}')
+		if [ -n "$ep" ]; then
+			score=$((score + 5))
+			details+="Service $svc has active endpoints. "
+		else
+			details+="Service $svc has no endpoints. "
+		fi
+	else
+		details+="Service $svc not found. "
+	fi
+
+	echo "$score/$max_points"
+	echo "DETAILS: $details"
 }
 
 # Q19: 5 points
 score_q19() {
-  local score=0
-  local max_points=5
-  local details=""
-  local ns="depths"
-  local svc="multi-port-svc"
-  
-  if resource_exists svc $svc $ns; then
-    score=$((score + 1))
-    details+="Service exists. "
-    
-    local port1=$(kubectl get svc $svc -n $ns -o jsonpath='{.spec.ports[?(@.port==80)].protocol}')
-    local port2=$(kubectl get svc $svc -n $ns -o jsonpath='{.spec.ports[?(@.port==53)].protocol}')
-    
-    if [[ "$port1" == "TCP" ]]; then
-      score=$((score + 2))
-      details+="Port 80 is TCP. "
-    fi
-    if [[ "$port2" == "UDP" ]]; then
-      score=$((score + 2))
-      details+="Port 53 is UDP. "
-    fi
-  else
-    details+="Service not found. "
-  fi
-  
-  echo "$score/$max_points"
-  echo "DETAILS: $details"
+	local score=0
+	local max_points=5
+	local details=""
+	local ns="depths"
+	local svc="multi-port-svc"
+
+	if resource_exists svc $svc $ns; then
+		score=$((score + 1))
+		details+="Service exists. "
+
+		local port1=$(kubectl get svc $svc -n $ns -o jsonpath='{.spec.ports[?(@.port==80)].protocol}')
+		local port2=$(kubectl get svc $svc -n $ns -o jsonpath='{.spec.ports[?(@.port==53)].protocol}')
+
+		if [[ "$port1" == "TCP" ]]; then
+			score=$((score + 2))
+			details+="Port 80 is TCP. "
+		fi
+		if [[ "$port2" == "UDP" ]]; then
+			score=$((score + 2))
+			details+="Port 53 is UDP. "
+		fi
+	else
+		details+="Service not found. "
+	fi
+
+	echo "$score/$max_points"
+	echo "DETAILS: $details"
 }
 
 # Q20: 6 points
 score_q20() {
-  local score=0
-  local max_points=6
-  local details=""
-  local ns="ocean"
-  local ing="rewrite-ingress"
-  
-  if resource_exists ingress $ing $ns; then
-    score=$((score + 2))
-    details+="Ingress $ing exists. "
-    
-    local host=$(kubectl get ingress $ing -n $ns -o jsonpath='{.spec.rules[0].host}')
-    if [[ "$host" == "susanoo.com" ]]; then
-      score=$((score + 2))
-      details+="Host is correct. "
-    fi
-    
-    local anno=$(kubectl get ingress $ing -n $ns -o jsonpath='{.metadata.annotations.nginx\.ingress\.kubernetes\.io/rewrite-target}')
-    if [[ "$anno" == "/\$2" ]]; then
-      score=$((score + 2))
-      details+="Rewrite annotation is correct. "
-    fi
-  else
-    details+="Ingress $ing not found. "
-  fi
-  
-  echo "$score/$max_points"
-  echo "DETAILS: $details"
+	local score=0
+	local max_points=6
+	local details=""
+	local ns="ocean"
+	local ing="rewrite-ingress"
+
+	if resource_exists ingress $ing $ns; then
+		score=$((score + 2))
+		details+="Ingress $ing exists. "
+
+		local host=$(kubectl get ingress $ing -n $ns -o jsonpath='{.spec.rules[0].host}')
+		if [[ "$host" == "susanoo.com" ]]; then
+			score=$((score + 2))
+			details+="Host is correct. "
+		fi
+
+		local anno=$(kubectl get ingress $ing -n $ns -o jsonpath='{.metadata.annotations.nginx\.ingress\.kubernetes\.io/rewrite-target}')
+		if [[ "$anno" == "/\$2" ]]; then
+			score=$((score + 2))
+			details+="Rewrite annotation is correct. "
+		fi
+	else
+		details+="Ingress $ing not found. "
+	fi
+
+	echo "$score/$max_points"
+	echo "DETAILS: $details"
 }

--- a/exams/ckad-simulation15/solutions.md
+++ b/exams/ckad-simulation15/solutions.md
@@ -8,6 +8,7 @@
 You need to modify the `Dockerfile` to use a multi-stage build. This involves adding a second `FROM` instruction and copying the built artifact from the first stage.
 
 **Solution:**
+
 ```bash
 cat <<EOF > ./exam/course/1/Dockerfile
 FROM golang:1.20-alpine AS builder
@@ -30,6 +31,7 @@ EOF
 Create a Pod with two containers sharing an `emptyDir` volume. The main container writes logs to a file in the volume, and the sidecar container tails that file.
 
 **Solution:**
+
 ```bash
 cat <<EOF | kubectl apply -f -
 apiVersion: v1
@@ -65,6 +67,7 @@ EOF
 Create a CronJob with `failedJobsHistoryLimit` and `suspend` properties set.
 
 **Solution:**
+
 ```bash
 cat <<EOF | kubectl apply -f -
 apiVersion: batch/v1
@@ -98,6 +101,7 @@ EOF
 Create a Pod for a batch task. The key here is setting the `restartPolicy` to `OnFailure` instead of the default `Always`.
 
 **Solution:**
+
 ```bash
 cat <<EOF | kubectl apply -f -
 apiVersion: v1
@@ -122,6 +126,7 @@ EOF
 Uninstall a Helm release from a specific namespace.
 
 **Solution:**
+
 ```bash
 helm uninstall ocean-api -n current
 ```
@@ -134,10 +139,13 @@ helm uninstall ocean-api -n current
 Create a Deployment and configure its rolling update strategy attributes.
 
 **Solution:**
+
 ```bash
 kubectl create deployment web-deploy --image=nginx:1.23 --replicas=4 -n reef --dry-run=client -o yaml > deploy.yaml
 ```
+
 Edit `deploy.yaml` to add the strategy:
+
 ```yaml
 apiVersion: apps/v1
 kind: Deployment
@@ -163,6 +171,7 @@ spec:
       - name: nginx
         image: nginx:1.23
 ```
+
 ```bash
 kubectl apply -f deploy.yaml
 ```
@@ -175,6 +184,7 @@ kubectl apply -f deploy.yaml
 Perform updates to a Deployment to generate history, then roll back to a specific revision.
 
 **Solution:**
+
 ```bash
 # Update to nginx:1.24 and record cause
 kubectl set image deployment/api-server nginx=nginx:1.24 -n lagoon
@@ -200,6 +210,7 @@ kubectl rollout undo deployment/api-server --to-revision=2 -n lagoon
 Create Kustomize resources with common labels and annotations.
 
 **Solution:**
+
 ```bash
 cd ./exam/course/8/
 kubectl create deployment app-deploy --image=nginx --dry-run=client -o yaml > deployment.yaml
@@ -229,6 +240,7 @@ kubectl apply -k . -n trench
 Fix the image of a Pod stuck in ErrImagePull. It's often easiest to recreate the pod.
 
 **Solution:**
+
 ```bash
 kubectl get pod backend-pod -n wave -o yaml > pod.yaml
 # Edit pod.yaml to change image from wrongregistry.k8s.io/nginx:alpine to nginx:alpine
@@ -245,6 +257,7 @@ kubectl apply -f pod.yaml
 Retrieve events, filter for Warnings, and save to a file.
 
 **Solution:**
+
 ```bash
 kubectl get events -n depths --field-selector type=Warning > ./exam/course/10/events.txt
 ```
@@ -257,6 +270,7 @@ kubectl get events -n depths --field-selector type=Warning > ./exam/course/10/ev
 Configure a gRPC liveness probe.
 
 **Solution:**
+
 ```bash
 cat <<EOF | kubectl apply -f -
 apiVersion: v1
@@ -284,6 +298,7 @@ EOF
 Create a ConfigMap from a directory and mount it as a volume in a Pod.
 
 **Solution:**
+
 ```bash
 kubectl create configmap app-config-dir --from-file=./exam/course/12/config-files/ -n tide
 
@@ -316,6 +331,7 @@ EOF
 Create a Secret and expose its values as environment variables.
 
 **Solution:**
+
 ```bash
 kubectl create secret generic db-credentials --from-literal=username=admin --from-literal=password=supersecretpassword -n coral
 
@@ -351,6 +367,7 @@ EOF
 Apply SecurityContext to a Pod and create a NetworkPolicy to deny ingress.
 
 **Solution:**
+
 ```bash
 cat <<EOF | kubectl apply -f -
 apiVersion: v1
@@ -396,6 +413,7 @@ EOF
 Use `kubectl debug` to attach an ephemeral container.
 
 **Solution:**
+
 ```bash
 kubectl debug -it target-pod -n reef --image=busybox --target=web -- custom-command
 # Alternatively, without interacting:
@@ -410,10 +428,11 @@ kubectl debug target-pod -n reef --image=busybox --container=debug-container
 Create a Deployment and a PodDisruptionBudget.
 
 **Solution:**
+
 ```bash
 kubectl create deployment critical-app --image=nginx --replicas=3 -n lagoon
 kubectl label deployment critical-app tier=critical -n lagoon
-# Label applies to pods automatically from deployment template if created this way? 
+# Label applies to pods automatically from deployment template if created this way?
 # Wait, kubectl create deployment adds app=critical-app label. To add tier=critical to pods, we need to patch or recreate.
 # It's better to use YAML.
 
@@ -458,6 +477,7 @@ EOF
 Create a default deny-all NetworkPolicy and a specific allow NetworkPolicy.
 
 **Solution:**
+
 ```bash
 cat <<EOF | kubectl apply -f -
 apiVersion: networking.k8s.io/v1
@@ -500,6 +520,7 @@ EOF
 Fix the Service selector to match the Pod's labels.
 
 **Solution:**
+
 ```bash
 kubectl edit service mesh-service -n wave
 # Change selector from app: wrong-label to app: mesh-app
@@ -513,6 +534,7 @@ kubectl edit service mesh-service -n wave
 Create a multi-port Service.
 
 **Solution:**
+
 ```bash
 cat <<EOF | kubectl apply -f -
 apiVersion: v1
@@ -543,6 +565,7 @@ EOF
 Create an Ingress with an annotation for rewrite-target.
 
 **Solution:**
+
 ```bash
 cat <<EOF | kubectl apply -f -
 apiVersion: networking.k8s.io/v1

--- a/exams/ckad-simulation16/manifests/setup/setup.yaml
+++ b/exams/ckad-simulation16/manifests/setup/setup.yaml
@@ -137,9 +137,9 @@ metadata:
     kubernetes.io/service-name: external-db-svc
 addressType: IPv4
 ports:
-  - name: mysql
-    port: 3306
+- name: mysql
+  port: 3306
 endpoints:
-  - addresses:
-      - "192.168.1.100"
-      - "192.168.1.101"
+- addresses:
+  - "192.168.1.100"
+  - "192.168.1.101"

--- a/exams/ckad-simulation16/post-setup.sh
+++ b/exams/ckad-simulation16/post-setup.sh
@@ -1,23 +1,23 @@
 #!/bin/bash
 exam_post_setup() {
-  local BASE_DIR="./exam/course/16"
-  
-  kubectl apply -f "exams/ckad-simulation16/manifests/setup/setup.yaml" 2>/dev/null || true
-  kubectl set image deployment/legacy-app -n verse app=nginx:1.15
-  kubectl rollout status deployment/legacy-app -n verse --timeout=60s || true
-  kubectl set image deployment/legacy-app -n verse app=nginx:1.16
-  kubectl rollout status deployment/legacy-app -n verse --timeout=60s || true
-  kubectl set image deployment/legacy-app -n verse app=nginx:missing-tag
-  
-  mkdir -p $BASE_DIR/q1/app
-  echo "Benzaiten Wisdom" > $BASE_DIR/q1/app/index.html
-  cat << 'EOF_FILE' > $BASE_DIR/q1/Dockerfile
+	local BASE_DIR="./exam/course/16"
+
+	kubectl apply -f "exams/ckad-simulation16/manifests/setup/setup.yaml" 2>/dev/null || true
+	kubectl set image deployment/legacy-app -n verse app=nginx:1.15
+	kubectl rollout status deployment/legacy-app -n verse --timeout=60s || true
+	kubectl set image deployment/legacy-app -n verse app=nginx:1.16
+	kubectl rollout status deployment/legacy-app -n verse --timeout=60s || true
+	kubectl set image deployment/legacy-app -n verse app=nginx:missing-tag
+
+	mkdir -p $BASE_DIR/q1/app
+	echo "Benzaiten Wisdom" >$BASE_DIR/q1/app/index.html
+	cat <<'EOF_FILE' >$BASE_DIR/q1/Dockerfile
 FROM nginx:alpine
 # TODO: Complete Dockerfile
 EOF_FILE
-  
-  mkdir -p $BASE_DIR/q5/chart/templates
-  cat <<'EOF' > $BASE_DIR/q5/chart/Chart.yaml
+
+	mkdir -p $BASE_DIR/q5/chart/templates
+	cat <<'EOF' >$BASE_DIR/q5/chart/Chart.yaml
 apiVersion: v2
 name: wisdom-app
 version: 0.1.0
@@ -26,21 +26,21 @@ dependencies:
     version: 15.1.0
     repository: https://charts.bitnami.com/bitnami
 EOF
-  cat <<'EOF' > $BASE_DIR/q5/chart/values.yaml
+	cat <<'EOF' >$BASE_DIR/q5/chart/values.yaml
 replicaCount: 1
 service:
   port: 80
 EOF
-  cat << 'EOF_FILE' > $BASE_DIR/q5/values.yaml
+	cat <<'EOF_FILE' >$BASE_DIR/q5/values.yaml
 # override values here
 EOF_FILE
 
-  mkdir -p $BASE_DIR/q8/base
-  cat <<'EOF' > $BASE_DIR/q8/base/kustomization.yaml
+	mkdir -p $BASE_DIR/q8/base
+	cat <<'EOF' >$BASE_DIR/q8/base/kustomization.yaml
 resources:
   - deployment.yaml
 EOF
-  cat <<'EOF' > $BASE_DIR/q8/base/deployment.yaml
+	cat <<'EOF' >$BASE_DIR/q8/base/deployment.yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -60,16 +60,16 @@ spec:
         image: nginx:alpine
 EOF
 
-  mkdir -p $BASE_DIR/q8/overlays/production
-  cat <<'EOF' > $BASE_DIR/q8/kustomization.yaml
+	mkdir -p $BASE_DIR/q8/overlays/production
+	cat <<'EOF' >$BASE_DIR/q8/kustomization.yaml
 # TODO: Complete Kustomize config
 EOF
 
-  mkdir -p $BASE_DIR/q10
-  mkdir -p $BASE_DIR/q13
-  echo -n "binary-data-test" > $BASE_DIR/q13/data.bin
-  mkdir -p $BASE_DIR/q15
-  mkdir -p $BASE_DIR/q19
+	mkdir -p $BASE_DIR/q10
+	mkdir -p $BASE_DIR/q13
+	echo -n "binary-data-test" >$BASE_DIR/q13/data.bin
+	mkdir -p $BASE_DIR/q15
+	mkdir -p $BASE_DIR/q19
 
-  return 0
+	return 0
 }

--- a/exams/ckad-simulation16/questions.md
+++ b/exams/ckad-simulation16/questions.md
@@ -85,6 +85,7 @@ Configure the Job to automatically delete itself 10 seconds after it finishes su
 
 Create a Pod named `shared-process-pod` in the `cadence` namespace.
 The Pod should run two containers:
+
 1. `app-container` using image `nginx:alpine`
 2. `debug-container` using image `busybox` running the command `sleep 3600`
 Enable process namespace sharing between the containers in this Pod so the `debug-container` can see processes running in the `app-container`.
@@ -160,6 +161,7 @@ Undo the rollout and rollback to exactly revision 2.
 A base kustomize configuration is at `./exam/course/16/q8/base`.
 Create an overlay for a `production` environment at `./exam/course/16/q8/overlays/production`.
 The overlay should:
+
 1. Change the namespace to `lyric`
 2. Apply a common label `env: production` to all resources
 3. Update the replicas of the deployment `app-deploy` to 4
@@ -235,6 +237,7 @@ Configure a Readiness probe that sends an HTTP GET request to `/ready` on port 8
 Create a Pod named `projected-pod` in the `melody` namespace using image `busybox`, command `sleep 3600`.
 Use a projected volume named `all-in-one` mounted at `/etc/projected`.
 The volume should project:
+
 1. A Downward API volume projecting the pod's labels into a file named `pod-labels.txt`
 2. A ConfigMap named `info-cm` projecting its contents
 3. A Secret named `info-secret` projecting its contents

--- a/exams/ckad-simulation16/scoring-functions.sh
+++ b/exams/ckad-simulation16/scoring-functions.sh
@@ -8,437 +8,437 @@ source "$SCRIPT_DIR/../../scripts/lib/common.sh" 2>/dev/null || true
 EXAM_DIR="./exam/course/16"
 
 score_q1() {
-  local score=0
-  local max_points=5
-  local details=""
-  
-  if resource_exists pod wisdom-server harmony; then
-    local img=$(kubectl get pod wisdom-server -n harmony -o jsonpath='{.spec.containers[0].image}')
-    if [[ "$img" == *"benzaiten-wisdom"* ]]; then
-      score=$((score + 5))
-      details="Pod created with correct image"
-    else
-      details="Pod image incorrect"
-    fi
-  else
-    details="Pod not found"
-  fi
-  
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+	local score=0
+	local max_points=5
+	local details=""
+
+	if resource_exists pod wisdom-server harmony; then
+		local img=$(kubectl get pod wisdom-server -n harmony -o jsonpath='{.spec.containers[0].image}')
+		if [[ "$img" == *"benzaiten-wisdom"* ]]; then
+			score=$((score + 5))
+			details="Pod created with correct image"
+		else
+			details="Pod image incorrect"
+		fi
+	else
+		details="Pod not found"
+	fi
+
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q2() {
-  local score=0
-  local max_points=6
-  local details=""
-  
-  if resource_exists pod ambassador-pod melody; then
-    score=$((score + 2))
-    local cm=$(kubectl get pod ambassador-pod -n melody -o jsonpath='{.spec.volumes[?(@.configMap.name=="haproxy-config")].configMap.name}')
-    if [ "$cm" == "haproxy-config" ]; then
-      score=$((score + 4))
-      details="Pod created with ambassador and configmap mounted"
-    else
-      details="ConfigMap not mounted"
-    fi
-  else
-    details="Pod not found"
-  fi
-  
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+	local score=0
+	local max_points=6
+	local details=""
+
+	if resource_exists pod ambassador-pod melody; then
+		score=$((score + 2))
+		local cm=$(kubectl get pod ambassador-pod -n melody -o jsonpath='{.spec.volumes[?(@.configMap.name=="haproxy-config")].configMap.name}')
+		if [ "$cm" == "haproxy-config" ]; then
+			score=$((score + 4))
+			details="Pod created with ambassador and configmap mounted"
+		else
+			details="ConfigMap not mounted"
+		fi
+	else
+		details="Pod not found"
+	fi
+
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q3() {
-  local score=0
-  local max_points=5
-  local details=""
-  
-  if resource_exists job data-cleanup rhythm; then
-    score=$((score + 2))
-    local ttl=$(kubectl get job data-cleanup -n rhythm -o jsonpath='{.spec.ttlSecondsAfterFinished}')
-    if [ "$ttl" == "10" ]; then
-      score=$((score + 3))
-      details="Job created with ttlSecondsAfterFinished=10"
-    else
-      details="Job created but ttl missing"
-    fi
-  else
-    details="Job not found"
-  fi
-  
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+	local score=0
+	local max_points=5
+	local details=""
+
+	if resource_exists job data-cleanup rhythm; then
+		score=$((score + 2))
+		local ttl=$(kubectl get job data-cleanup -n rhythm -o jsonpath='{.spec.ttlSecondsAfterFinished}')
+		if [ "$ttl" == "10" ]; then
+			score=$((score + 3))
+			details="Job created with ttlSecondsAfterFinished=10"
+		else
+			details="Job created but ttl missing"
+		fi
+	else
+		details="Job not found"
+	fi
+
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q4() {
-  local score=0
-  local max_points=6
-  local details=""
-  
-  if resource_exists pod shared-process-pod cadence; then
-    score=$((score + 2))
-    local share=$(kubectl get pod shared-process-pod -n cadence -o jsonpath='{.spec.shareProcessNamespace}')
-    if [ "$share" == "true" ]; then
-      score=$((score + 4))
-      details="Pod created with shareProcessNamespace enabled"
-    else
-      details="shareProcessNamespace not enabled"
-    fi
-  else
-    details="Pod not found"
-  fi
-  
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+	local score=0
+	local max_points=6
+	local details=""
+
+	if resource_exists pod shared-process-pod cadence; then
+		score=$((score + 2))
+		local share=$(kubectl get pod shared-process-pod -n cadence -o jsonpath='{.spec.shareProcessNamespace}')
+		if [ "$share" == "true" ]; then
+			score=$((score + 4))
+			details="Pod created with shareProcessNamespace enabled"
+		else
+			details="shareProcessNamespace not enabled"
+		fi
+	else
+		details="Pod not found"
+	fi
+
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q5() {
-  local score=0
-  local max_points=6
-  local details=""
-  
-  if helm ls -n chorus | grep -q wisdom-app; then
-    score=$((score + 3))
-    local rep=$(helm get values wisdom-app -n chorus | grep replicaCount)
-    if [[ "$rep" != "" ]]; then
-        score=$((score + 3))
-        details="Helm release exists with values"
-    else
-        details="Helm release exists but custom values might not be set"
-    fi
-  else
-    details="Helm release not found"
-  fi
-  
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+	local score=0
+	local max_points=6
+	local details=""
+
+	if helm ls -n chorus | grep -q wisdom-app; then
+		score=$((score + 3))
+		local rep=$(helm get values wisdom-app -n chorus | grep replicaCount)
+		if [[ "$rep" != "" ]]; then
+			score=$((score + 3))
+			details="Helm release exists with values"
+		else
+			details="Helm release exists but custom values might not be set"
+		fi
+	else
+		details="Helm release not found"
+	fi
+
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q6() {
-  local score=0
-  local max_points=7
-  local details=""
-  
-  if resource_exists deployment rolling-deploy sonata; then
-    score=$((score + 2))
-    local surge=$(kubectl get deploy rolling-deploy -n sonata -o jsonpath='{.spec.strategy.rollingUpdate.maxSurge}')
-    local unav=$(kubectl get deploy rolling-deploy -n sonata -o jsonpath='{.spec.strategy.rollingUpdate.maxUnavailable}')
-    if [ "$surge" == "40%" ] && [ "$unav" == "20%" ]; then
-      score=$((score + 5))
-      details="Deployment created with correct rolling update strategy"
-    else
-      details="Deployment strategy incorrect"
-    fi
-  else
-    details="Deployment not found"
-  fi
-  
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+	local score=0
+	local max_points=7
+	local details=""
+
+	if resource_exists deployment rolling-deploy sonata; then
+		score=$((score + 2))
+		local surge=$(kubectl get deploy rolling-deploy -n sonata -o jsonpath='{.spec.strategy.rollingUpdate.maxSurge}')
+		local unav=$(kubectl get deploy rolling-deploy -n sonata -o jsonpath='{.spec.strategy.rollingUpdate.maxUnavailable}')
+		if [ "$surge" == "40%" ] && [ "$unav" == "20%" ]; then
+			score=$((score + 5))
+			details="Deployment created with correct rolling update strategy"
+		else
+			details="Deployment strategy incorrect"
+		fi
+	else
+		details="Deployment not found"
+	fi
+
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q7() {
-  local score=0
-  local max_points=5
-  local details=""
-  
-  if resource_exists deployment legacy-app verse; then
-    local rev=$(kubectl get deploy legacy-app -n verse -o jsonpath='{.metadata.annotations.deployment\.kubernetes\.io/revision}')
-    if [ "$rev" == "3" ] || [ "$rev" == "4" ]; then
-      score=$((score + 5))
-      details="Deployment undone"
-    else
-      details="Deployment revision check - you might have passed if you rolled back"
-      score=5
-    fi
-  else
-    details="Deployment not found"
-  fi
-  
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+	local score=0
+	local max_points=5
+	local details=""
+
+	if resource_exists deployment legacy-app verse; then
+		local rev=$(kubectl get deploy legacy-app -n verse -o jsonpath='{.metadata.annotations.deployment\.kubernetes\.io/revision}')
+		if [ "$rev" == "3" ] || [ "$rev" == "4" ]; then
+			score=$((score + 5))
+			details="Deployment undone"
+		else
+			details="Deployment revision check - you might have passed if you rolled back"
+			score=5
+		fi
+	else
+		details="Deployment not found"
+	fi
+
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q8() {
-  local score=0
-  local max_points=8
-  local details=""
-  
-  if resource_exists deployment app-deploy lyric; then
-    score=$((score + 4))
-    local rep=$(kubectl get deploy app-deploy -n lyric -o jsonpath='{.spec.replicas}')
-    if [ "$rep" == "4" ]; then
-      score=$((score + 4))
-      details="Overlay applied successfully"
-    else
-      details="Overlay not applied correctly"
-    fi
-  else
-    details="Deployment not found in lyric namespace"
-  fi
-  
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+	local score=0
+	local max_points=8
+	local details=""
+
+	if resource_exists deployment app-deploy lyric; then
+		score=$((score + 4))
+		local rep=$(kubectl get deploy app-deploy -n lyric -o jsonpath='{.spec.replicas}')
+		if [ "$rep" == "4" ]; then
+			score=$((score + 4))
+			details="Overlay applied successfully"
+		else
+			details="Overlay not applied correctly"
+		fi
+	else
+		details="Deployment not found in lyric namespace"
+	fi
+
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q9() {
-  local score=0
-  local max_points=5
-  local details=""
-  
-  if resource_exists pod metrics-pod tempo; then
-    local status=$(kubectl get pod metrics-pod -n tempo -o jsonpath='{.status.phase}')
-    if [ "$status" == "Running" ]; then
-      score=$((score + 5))
-      details="Pod is running"
-    else
-      details="Pod is not running"
-    fi
-  else
-    details="Pod not found"
-  fi
-  
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+	local score=0
+	local max_points=5
+	local details=""
+
+	if resource_exists pod metrics-pod tempo; then
+		local status=$(kubectl get pod metrics-pod -n tempo -o jsonpath='{.status.phase}')
+		if [ "$status" == "Running" ]; then
+			score=$((score + 5))
+			details="Pod is running"
+		else
+			details="Pod is not running"
+		fi
+	else
+		details="Pod not found"
+	fi
+
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q10() {
-  local score=0
-  local max_points=6
-  local details=""
-  
-  if [ -f "./exam/course/16/q10/metrics.txt" ] || [ -f "./exam/course/16/q10/metrics.txt" ]; then
-    local val=$(cat ./exam/course/16/q10/metrics.txt 2>/dev/null || cat ./exam/course/16/q10/metrics.txt 2>/dev/null)
-    if [[ -n "$val" ]]; then
-      score=$((score + 6))
-      details="Metrics file found and has content"
-    else
-      details="Metrics file empty"
-    fi
-  else
-    details="Metrics file not found"
-  fi
-  
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+	local score=0
+	local max_points=6
+	local details=""
+
+	if [ -f "./exam/course/16/q10/metrics.txt" ] || [ -f "./exam/course/16/q10/metrics.txt" ]; then
+		local val=$(cat ./exam/course/16/q10/metrics.txt 2>/dev/null || cat ./exam/course/16/q10/metrics.txt 2>/dev/null)
+		if [[ -n "$val" ]]; then
+			score=$((score + 6))
+			details="Metrics file found and has content"
+		else
+			details="Metrics file empty"
+		fi
+	else
+		details="Metrics file not found"
+	fi
+
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q11() {
-  local score=0
-  local max_points=6
-  local details=""
-  
-  if resource_exists pod health-check harmony; then
-    score=$((score + 2))
-    local live=$(kubectl get pod health-check -n harmony -o jsonpath='{.spec.containers[0].livenessProbe}')
-    local read=$(kubectl get pod health-check -n harmony -o jsonpath='{.spec.containers[0].readinessProbe}')
-    if [[ -n "$live" ]] && [[ -n "$read" ]]; then
-      score=$((score + 4))
-      details="Pod has both probes"
-    else
-      details="Probes missing"
-    fi
-  else
-    details="Pod not found"
-  fi
-  
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+	local score=0
+	local max_points=6
+	local details=""
+
+	if resource_exists pod health-check harmony; then
+		score=$((score + 2))
+		local live=$(kubectl get pod health-check -n harmony -o jsonpath='{.spec.containers[0].livenessProbe}')
+		local read=$(kubectl get pod health-check -n harmony -o jsonpath='{.spec.containers[0].readinessProbe}')
+		if [[ -n "$live" ]] && [[ -n "$read" ]]; then
+			score=$((score + 4))
+			details="Pod has both probes"
+		else
+			details="Probes missing"
+		fi
+	else
+		details="Pod not found"
+	fi
+
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q12() {
-  local score=0
-  local max_points=6
-  local details=""
-  
-  if resource_exists pod projected-pod melody; then
-    score=$((score + 2))
-    local proj=$(kubectl get pod projected-pod -n melody -o jsonpath='{.spec.volumes[?(@.projected)].projected.sources}')
-    if [[ "$proj" == *"downwardAPI"* ]] && [[ "$proj" == *"configMap"* ]] && [[ "$proj" == *"secret"* ]]; then
-      score=$((score + 4))
-      details="Projected volume configured correctly"
-    else
-      details="Projected volume sources missing"
-    fi
-  else
-    details="Pod not found"
-  fi
-  
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+	local score=0
+	local max_points=6
+	local details=""
+
+	if resource_exists pod projected-pod melody; then
+		score=$((score + 2))
+		local proj=$(kubectl get pod projected-pod -n melody -o jsonpath='{.spec.volumes[?(@.projected)].projected.sources}')
+		if [[ "$proj" == *"downwardAPI"* ]] && [[ "$proj" == *"configMap"* ]] && [[ "$proj" == *"secret"* ]]; then
+			score=$((score + 4))
+			details="Projected volume configured correctly"
+		else
+			details="Projected volume sources missing"
+		fi
+	else
+		details="Pod not found"
+	fi
+
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q13() {
-  local score=0
-  local max_points=4
-  local details=""
-  
-  if resource_exists configmap binary-config rhythm; then
-    local bin=$(kubectl get cm binary-config -n rhythm -o jsonpath='{.binaryData}')
-    if [[ -n "$bin" ]]; then
-      score=$((score + 4))
-      details="ConfigMap with binary data found"
-    else
-      details="Binary data missing"
-    fi
-  else
-    details="ConfigMap not found"
-  fi
-  
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+	local score=0
+	local max_points=4
+	local details=""
+
+	if resource_exists configmap binary-config rhythm; then
+		local bin=$(kubectl get cm binary-config -n rhythm -o jsonpath='{.binaryData}')
+		if [[ -n "$bin" ]]; then
+			score=$((score + 4))
+			details="ConfigMap with binary data found"
+		else
+			details="Binary data missing"
+		fi
+	else
+		details="ConfigMap not found"
+	fi
+
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q14() {
-  local score=0
-  local max_points=5
-  local details=""
-  
-  if resource_exists pod selinux-pod cadence; then
-    score=$((score + 2))
-    local se=$(kubectl get pod selinux-pod -n cadence -o jsonpath='{.spec.securityContext.seLinuxOptions.level}')
-    if [ "$se" == "s0:c123,c456" ]; then
-      score=$((score + 3))
-      details="SELinux options set correctly"
-    else
-      details="SELinux options incorrect"
-    fi
-  else
-    details="Pod not found"
-  fi
-  
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+	local score=0
+	local max_points=5
+	local details=""
+
+	if resource_exists pod selinux-pod cadence; then
+		score=$((score + 2))
+		local se=$(kubectl get pod selinux-pod -n cadence -o jsonpath='{.spec.securityContext.seLinuxOptions.level}')
+		if [ "$se" == "s0:c123,c456" ]; then
+			score=$((score + 3))
+			details="SELinux options set correctly"
+		else
+			details="SELinux options incorrect"
+		fi
+	else
+		details="Pod not found"
+	fi
+
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q15() {
-  local score=0
-  local max_points=4
-  local details=""
-  
-  if [ -f "./exam/course/16/q15/token.txt" ] || [ -f "./exam/course/16/q15/token.txt" ]; then
-    local val=$(cat ./exam/course/16/q15/token.txt 2>/dev/null || cat ./exam/course/16/q15/token.txt 2>/dev/null)
-    if [[ -n "$val" ]]; then
-      score=$((score + 4))
-      details="Token file found and has content"
-    else
-      details="Token file empty"
-    fi
-  else
-    details="Token file not found"
-  fi
-  
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+	local score=0
+	local max_points=4
+	local details=""
+
+	if [ -f "./exam/course/16/q15/token.txt" ] || [ -f "./exam/course/16/q15/token.txt" ]; then
+		local val=$(cat ./exam/course/16/q15/token.txt 2>/dev/null || cat ./exam/course/16/q15/token.txt 2>/dev/null)
+		if [[ -n "$val" ]]; then
+			score=$((score + 4))
+			details="Token file found and has content"
+		else
+			details="Token file empty"
+		fi
+	else
+		details="Token file not found"
+	fi
+
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q16() {
-  local score=0
-  local max_points=7
-  local details=""
-  
-  if resource_exists networkpolicy port-range-allow chorus; then
-    score=$((score + 3))
-    local endp=$(kubectl get netpol port-range-allow -n chorus -o jsonpath='{.spec.ingress[0].ports[0].endPort}')
-    if [ "$endp" == "3010" ]; then
-      score=$((score + 4))
-      details="NetworkPolicy with port range found"
-    else
-      details="Port range not set correctly"
-    fi
-  else
-    details="NetworkPolicy not found"
-  fi
-  
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+	local score=0
+	local max_points=7
+	local details=""
+
+	if resource_exists networkpolicy port-range-allow chorus; then
+		score=$((score + 3))
+		local endp=$(kubectl get netpol port-range-allow -n chorus -o jsonpath='{.spec.ingress[0].ports[0].endPort}')
+		if [ "$endp" == "3010" ]; then
+			score=$((score + 4))
+			details="NetworkPolicy with port range found"
+		else
+			details="Port range not set correctly"
+		fi
+	else
+		details="NetworkPolicy not found"
+	fi
+
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q17() {
-  local score=0
-  local max_points=6
-  local details=""
-  
-  if resource_exists networkpolicy egress-external-only verse; then
-    score=$((score + 2))
-    local exc=$(kubectl get netpol egress-external-only -n verse -o jsonpath='{.spec.egress[0].to[0].ipBlock.except}')
-    if [[ -n "$exc" ]]; then
-      score=$((score + 4))
-      details="NetworkPolicy with except block found"
-    else
-      details="Except block missing"
-    fi
-  else
-    details="NetworkPolicy not found"
-  fi
-  
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+	local score=0
+	local max_points=6
+	local details=""
+
+	if resource_exists networkpolicy egress-external-only verse; then
+		score=$((score + 2))
+		local exc=$(kubectl get netpol egress-external-only -n verse -o jsonpath='{.spec.egress[0].to[0].ipBlock.except}')
+		if [[ -n "$exc" ]]; then
+			score=$((score + 4))
+			details="NetworkPolicy with except block found"
+		else
+			details="Except block missing"
+		fi
+	else
+		details="NetworkPolicy not found"
+	fi
+
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q18() {
-  local score=0
-  local max_points=6
-  local details=""
-  
-  if resource_exists ingress multi-tls-ingress lyric; then
-    score=$((score + 2))
-    local tls=$(kubectl get ingress multi-tls-ingress -n lyric -o jsonpath='{.spec.tls}')
-    if [[ "$tls" == *"app1-tls"* ]] && [[ "$tls" == *"app2-tls"* ]]; then
-      score=$((score + 4))
-      details="Ingress with multiple TLS hosts found"
-    else
-      details="TLS configuration incorrect"
-    fi
-  else
-    details="Ingress not found"
-  fi
-  
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+	local score=0
+	local max_points=6
+	local details=""
+
+	if resource_exists ingress multi-tls-ingress lyric; then
+		score=$((score + 2))
+		local tls=$(kubectl get ingress multi-tls-ingress -n lyric -o jsonpath='{.spec.tls}')
+		if [[ "$tls" == *"app1-tls"* ]] && [[ "$tls" == *"app2-tls"* ]]; then
+			score=$((score + 4))
+			details="Ingress with multiple TLS hosts found"
+		else
+			details="TLS configuration incorrect"
+		fi
+	else
+		details="Ingress not found"
+	fi
+
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q19() {
-  local score=0
-  local max_points=5
-  local details=""
-  
-  if [ -f "./exam/course/16/q19/endpoints.txt" ] || [ -f "./exam/course/16/q19/endpoints.txt" ]; then
-    local val=$(cat ./exam/course/16/q19/endpoints.txt 2>/dev/null || cat ./exam/course/16/q19/endpoints.txt 2>/dev/null)
-    if [[ -n "$val" ]]; then
-      score=$((score + 5))
-      details="Endpoints file found and has content"
-    else
-      details="Endpoints file empty"
-    fi
-  else
-    details="Endpoints file not found"
-  fi
-  
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+	local score=0
+	local max_points=5
+	local details=""
+
+	if [ -f "./exam/course/16/q19/endpoints.txt" ] || [ -f "./exam/course/16/q19/endpoints.txt" ]; then
+		local val=$(cat ./exam/course/16/q19/endpoints.txt 2>/dev/null || cat ./exam/course/16/q19/endpoints.txt 2>/dev/null)
+		if [[ -n "$val" ]]; then
+			score=$((score + 5))
+			details="Endpoints file found and has content"
+		else
+			details="Endpoints file empty"
+		fi
+	else
+		details="Endpoints file not found"
+	fi
+
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q20() {
-  local score=0
-  local max_points=6
-  local details=""
-  
-  if resource_exists service local-app-svc aria; then
-    score=$((score + 2))
-    local pol=$(kubectl get svc local-app-svc -n aria -o jsonpath='{.spec.externalTrafficPolicy}')
-    if [ "$pol" == "Local" ]; then
-      score=$((score + 4))
-      details="Service with Local externalTrafficPolicy found"
-    else
-      details="externalTrafficPolicy not set to Local"
-    fi
-  else
-    details="Service not found"
-  fi
-  
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+	local score=0
+	local max_points=6
+	local details=""
+
+	if resource_exists service local-app-svc aria; then
+		score=$((score + 2))
+		local pol=$(kubectl get svc local-app-svc -n aria -o jsonpath='{.spec.externalTrafficPolicy}')
+		if [ "$pol" == "Local" ]; then
+			score=$((score + 4))
+			details="Service with Local externalTrafficPolicy found"
+		else
+			details="externalTrafficPolicy not set to Local"
+		fi
+	else
+		details="Service not found"
+	fi
+
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }

--- a/exams/ckad-simulation17/post-setup.sh
+++ b/exams/ckad-simulation17/post-setup.sh
@@ -3,26 +3,24 @@
 # Post-setup script for Simulation 17
 
 function exam_post_setup() {
-    echo "Running post-setup tasks for Simulation 17..."
-    
-    # Q5: Helm chart and release setup
-    mkdir -p ./exam/course/5/
-    helm create ./exam/course/5/battle-chart > /dev/null 2>&1
-    
-    # The default nginx chart works, so let's just make sure it's installed
-    helm install battle-web ./exam/course/5/battle-chart -n garrison --set replicaCount=1 > /dev/null 2>&1
-    
-    
-    
-    # Q8: Kustomize setup
-    mkdir -p ./exam/course/8/
-    cat <<EOF2 > ./exam/course/8/kustomization.yaml
+	echo "Running post-setup tasks for Simulation 17..."
+
+	# Q5: Helm chart and release setup
+	mkdir -p ./exam/course/5/
+	helm create ./exam/course/5/battle-chart >/dev/null 2>&1
+
+	# The default nginx chart works, so let's just make sure it's installed
+	helm install battle-web ./exam/course/5/battle-chart -n garrison --set replicaCount=1 >/dev/null 2>&1
+
+	# Q8: Kustomize setup
+	mkdir -p ./exam/course/8/
+	cat <<EOF2 >./exam/course/8/kustomization.yaml
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - deployment.yaml
 EOF2
-    cat <<EOF2 > ./exam/course/8/deployment.yaml
+	cat <<EOF2 >./exam/course/8/deployment.yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -43,35 +41,35 @@ spec:
         image: nginx:1.21.0-alpine
 EOF2
 
-  # === Auto-generated starter files ===
-  local BASE_DIR="./exam/course"
-  mkdir -p "$BASE_DIR/1" "$BASE_DIR/2" "$BASE_DIR/3" "$BASE_DIR/4" "$BASE_DIR/6" "$BASE_DIR/8"
-  mkdir -p "$BASE_DIR/12" "$BASE_DIR/13" "$BASE_DIR/14" "$BASE_DIR/15" "$BASE_DIR/16" "$BASE_DIR/17" "$BASE_DIR/18" "$BASE_DIR/19" "$BASE_DIR/20"
+	# === Auto-generated starter files ===
+	local BASE_DIR="./exam/course"
+	mkdir -p "$BASE_DIR/1" "$BASE_DIR/2" "$BASE_DIR/3" "$BASE_DIR/4" "$BASE_DIR/6" "$BASE_DIR/8"
+	mkdir -p "$BASE_DIR/12" "$BASE_DIR/13" "$BASE_DIR/14" "$BASE_DIR/15" "$BASE_DIR/16" "$BASE_DIR/17" "$BASE_DIR/18" "$BASE_DIR/19" "$BASE_DIR/20"
 
-  for i in 1 2 3 4 6 12 13 14 15 16 17 18 19 20; do
-    # Just touch them or make empty manifests. Actually for yaml files:
-    cat << 'EOF_FILE' > "$BASE_DIR/$i/stub.yaml"
+	for i in 1 2 3 4 6 12 13 14 15 16 17 18 19 20; do
+		# Just touch them or make empty manifests. Actually for yaml files:
+		cat <<'EOF_FILE' >"$BASE_DIR/$i/stub.yaml"
 # TODO: Complete this manifest per the task instructions
 EOF_FILE
-  done
+	done
 
-  # Specific file names based on questions:
-  mv "$BASE_DIR/1/stub.yaml" "$BASE_DIR/1/pod.yaml"
-  mv "$BASE_DIR/2/stub.yaml" "$BASE_DIR/2/init-pod.yaml"
-  mv "$BASE_DIR/3/stub.yaml" "$BASE_DIR/3/cronjob.yaml"
-  mv "$BASE_DIR/4/stub.yaml" "$BASE_DIR/4/shared-pid.yaml"
-  mv "$BASE_DIR/6/stub.yaml" "$BASE_DIR/6/deploy.yaml"
-  mv "$BASE_DIR/12/stub.yaml" "$BASE_DIR/12/downward.yaml"
-  mv "$BASE_DIR/13/stub.yaml" "$BASE_DIR/13/sa-pod.yaml"
-  mv "$BASE_DIR/14/stub.yaml" "$BASE_DIR/14/seccomp.yaml"
-  mv "$BASE_DIR/15/stub.yaml" "$BASE_DIR/15/multi-secret.yaml"
-  mv "$BASE_DIR/16/stub.yaml" "$BASE_DIR/16/limit-range.yaml"
-  mv "$BASE_DIR/17/stub.yaml" "$BASE_DIR/17/netpol.yaml"
-  mv "$BASE_DIR/18/stub.yaml" "$BASE_DIR/18/ingress.yaml"
-  mv "$BASE_DIR/19/stub.yaml" "$BASE_DIR/19/manual-svc.yaml"
-  mv "$BASE_DIR/20/stub.yaml" "$BASE_DIR/20/coredns.yaml"
+	# Specific file names based on questions:
+	mv "$BASE_DIR/1/stub.yaml" "$BASE_DIR/1/pod.yaml"
+	mv "$BASE_DIR/2/stub.yaml" "$BASE_DIR/2/init-pod.yaml"
+	mv "$BASE_DIR/3/stub.yaml" "$BASE_DIR/3/cronjob.yaml"
+	mv "$BASE_DIR/4/stub.yaml" "$BASE_DIR/4/shared-pid.yaml"
+	mv "$BASE_DIR/6/stub.yaml" "$BASE_DIR/6/deploy.yaml"
+	mv "$BASE_DIR/12/stub.yaml" "$BASE_DIR/12/downward.yaml"
+	mv "$BASE_DIR/13/stub.yaml" "$BASE_DIR/13/sa-pod.yaml"
+	mv "$BASE_DIR/14/stub.yaml" "$BASE_DIR/14/seccomp.yaml"
+	mv "$BASE_DIR/15/stub.yaml" "$BASE_DIR/15/multi-secret.yaml"
+	mv "$BASE_DIR/16/stub.yaml" "$BASE_DIR/16/limit-range.yaml"
+	mv "$BASE_DIR/17/stub.yaml" "$BASE_DIR/17/netpol.yaml"
+	mv "$BASE_DIR/18/stub.yaml" "$BASE_DIR/18/ingress.yaml"
+	mv "$BASE_DIR/19/stub.yaml" "$BASE_DIR/19/manual-svc.yaml"
+	mv "$BASE_DIR/20/stub.yaml" "$BASE_DIR/20/coredns.yaml"
 
-  echo "Post-setup complete."
-  return 0
+	echo "Post-setup complete."
+	return 0
 }
 exam_post_setup

--- a/exams/ckad-simulation17/questions.md
+++ b/exams/ckad-simulation17/questions.md
@@ -26,9 +26,11 @@
 | **File to create** | `./exam/course/1/pod.yaml` |
 
 ### Task
+
 Create a Pod named `entry-override` in the `fortress` namespace using the `nginx:alpine` image.
 The image normally starts nginx. However, you must override both the entrypoint and the command.
 Configure the Pod to run `sleep` for `3600` seconds by passing them appropriately to the container.
+
 - Command (Entrypoint override): `["sleep"]`
 - Args (CMD override): `["3600"]`
 Save the manifest to `./exam/course/1/pod.yaml`.
@@ -47,7 +49,9 @@ Save the manifest to `./exam/course/1/pod.yaml`.
 | **File to create** | `./exam/course/2/init-pod.yaml` |
 
 ### Task
+
 Create a ConfigMap named `init-script-cm` in the `fortress` namespace containing a single key `setup.sh` with the content:
+
 ```bash
 #!/bin/sh
 echo "Initialization successful!" > /work-dir/index.html
@@ -56,6 +60,7 @@ echo "Initialization successful!" > /work-dir/index.html
 Then create a Pod named `web-setup` using the `nginx:alpine` image.
 Add an init container to the Pod using the `busybox:1.36` image named `init-setup`.
 The init container should:
+
 1. Mount the ConfigMap `init-script-cm` at `/scripts`
 2. Mount an emptyDir volume named `work-vol` at `/work-dir`
 3. Execute the script: `sh /scripts/setup.sh`
@@ -77,7 +82,9 @@ Save the Pod manifest to `./exam/course/2/init-pod.yaml`.
 | **File to create** | `./exam/course/3/cronjob.yaml` |
 
 ### Task
+
 Create a CronJob named `siege-report` in the `siege` namespace.
+
 - It should run a container using the `busybox:1.36` image.
 - The command should be `/bin/sh, -c, date; echo Hello from siege`.
 - It should run every hour on the half hour (e.g., 00:30, 01:30).
@@ -98,8 +105,10 @@ Save the CronJob manifest to `./exam/course/3/cronjob.yaml`.
 | **File to create** | `./exam/course/4/shared-pid.yaml` |
 
 ### Task
+
 Create a multi-container Pod named `process-monitor` in the `bastion` namespace.
 The Pod must share the PID namespace between all containers.
+
 - Container 1: `nginx-app` using `nginx:alpine` image.
 - Container 2: `monitor-app` using `busybox:1.36` image.
 The `monitor-app` container should run a continuous loop listing processes every 5 seconds:
@@ -121,6 +130,7 @@ Save the manifest to `./exam/course/4/shared-pid.yaml`.
 | **Resources** | Helm |
 
 ### Task
+
 A Helm release named `battle-web` exists in the `garrison` namespace.
 Upgrade it using the chart located at `./exam/course/5/battle-chart/`.
 However, the upgrade must be ATOMIC (if it fails, it rolls back automatically) and have a timeout of `1m` (1 minute).
@@ -141,7 +151,9 @@ Note: The underlying deployment may have a failing probe if configured incorrect
 | **File to create** | `./exam/course/6/deploy.yaml` |
 
 ### Task
+
 Create a Deployment named `citadel-guard` in the `citadel` namespace.
+
 - Replicas: `4`
 - Image: `nginx:1.24.0-alpine`
 - Labels: `app=guard`
@@ -161,8 +173,10 @@ Save the manifest to `./exam/course/6/deploy.yaml` and apply it.
 | **Resources** | Deployment, Service |
 
 ### Task
+
 In the `rampart` namespace, there is a deployment named `api-server-blue` and a service named `api-svc`.
 Currently, `api-svc` routes traffic to the `api-server-blue` pods.
+
 1. Create a new deployment named `api-server-green` with the image `nginx:1.25.0-alpine` and `app: api-server-green` labels. Set replicas to 2.
 2. Update the `api-svc` Service to route traffic to the `api-server-green` pods instead of `blue`.
 3. Do not delete the `api-server-blue` deployment.
@@ -181,8 +195,10 @@ Currently, `api-svc` routes traffic to the `api-server-blue` pods.
 | **File to create** | `./exam/course/8/kustomization.yaml` |
 
 ### Task
+
 A base kustomization structure exists at `./exam/course/8/`.
 Modify the `kustomization.yaml` file in this directory to apply two transformations to the base resources:
+
 1. Override the `nginx` image to use `nginx:1.23.0-alpine`.
 2. Apply a patch to scale the `vanguard-web` deployment to `5` replicas. (You can create a patch file in the same directory or use inline patches).
 Apply the customized manifests to the `vanguard` namespace.
@@ -201,6 +217,7 @@ Save your built manifests to `./exam/course/8/kustomize-output.yaml`.
 | **Resources** | Pod |
 
 ### Task
+
 A Pod named `data-processor` in the `sentinel` namespace is crashing.
 Identify the issue (it is being OOMKilled).
 Modify the Pod (you may need to delete and recreate it) to increase its memory limit to `256Mi`. Keep the requests at `64Mi`.
@@ -219,6 +236,7 @@ Ensure the Pod reaches the `Running` state.
 | **Resources** | Pod (Ephemeral Container) |
 
 ### Task
+
 The Pod `secure-app` in the `outpost` namespace contains a distroless container that lacks a shell.
 You need to inspect its filesystem.
 Add an ephemeral container to `secure-app` using the `busybox:1.36` image.
@@ -238,9 +256,11 @@ Ensure the ephemeral container can run interactively (it must stay running so th
 | **Resources** | Deployment, ResourceQuota |
 
 ### Task
+
 A Deployment named `weapon-smith` in the `armory` namespace is failing to scale up its pods due to a `ResourceQuota` named `armory-quota`.
 Troubleshoot the issue and adjust the `weapon-smith` deployment so that its pods fit within the quota constraints.
 Requirements for `weapon-smith` pods:
+
 - They must request exactly `100m` CPU and `128Mi` memory.
 - You cannot modify or delete the `armory-quota` ResourceQuota itself.
 Scale the deployment to `3` replicas if it's not already.
@@ -259,9 +279,11 @@ Scale the deployment to `3` replicas if it's not already.
 | **File to create** | `./exam/course/12/downward.yaml` |
 
 ### Task
+
 Create a Pod named `resource-aware` in the `fortress` namespace using the `busybox:1.36` image.
 It should run the command `sleep 3600`.
 Configure the container with:
+
 - CPU Request: `200m`
 - Memory Limit: `256Mi`
 Expose the Pod's CPU request and Memory limit as environment variables using the Downward API:
@@ -283,6 +305,7 @@ Save the manifest to `./exam/course/12/downward.yaml`.
 | **File to create** | `./exam/course/13/sa-pod.yaml` |
 
 ### Task
+
 1. Create a ServiceAccount named `stealth-sa` in the `siege` namespace.
 2. Create a Pod named `stealth-pod` in the same namespace using the `nginx:alpine` image and the `stealth-sa` ServiceAccount.
 3. The pod MUST NOT automount the ServiceAccount token by default (configure `automountServiceAccountToken: false` on the Pod or ServiceAccount).
@@ -303,6 +326,7 @@ Save the manifest to `./exam/course/13/sa-pod.yaml`.
 | **File to create** | `./exam/course/14/seccomp.yaml` |
 
 ### Task
+
 Create a Pod named `secure-workload` in the `bastion` namespace using the `nginx:alpine` image.
 Configure the Pod's SecurityContext to use the `RuntimeDefault` seccomp profile.
 Ensure the container runs as a non-root user (e.g., `runAsUser: 1000` and `runAsNonRoot: true`).
@@ -322,6 +346,7 @@ Save the manifest to `./exam/course/14/seccomp.yaml`.
 | **File to create** | `./exam/course/15/multi-secret.yaml` |
 
 ### Task
+
 1. Create a Secret named `db-credentials` in the `citadel` namespace containing two keys: `username` (value `admin`) and `password` (value `hachiman_rocks`).
 2. Create a Pod named `db-consumer` using the `alpine:3.18` image running `sleep 3600`.
 3. Mount the `db-credentials` secret as a volume at `/etc/db-creds/`.
@@ -342,8 +367,10 @@ Save the manifest to `./exam/course/15/multi-secret.yaml`.
 | **File to create** | `./exam/course/16/limit-range.yaml` |
 
 ### Task
+
 Create a LimitRange named `rampart-limits` in the `rampart` namespace.
 It should enforce the following default limits for all new Pods:
+
 - Default Limit: `Memory 512Mi`, `CPU 500m`
 - Default Request: `Memory 256Mi`, `CPU 200m`
 
@@ -364,9 +391,11 @@ Save the LimitRange and Pod manifests to `./exam/course/16/limit-range.yaml`.
 | **File to create** | `./exam/course/17/netpol.yaml` |
 
 ### Task
+
 Create a NetworkPolicy named `protect-db` in the `vanguard` namespace.
 It should apply to pods with the label `role=db`.
 Allow INGRESS traffic on TCP port `5432` from:
+
 1. Pods in the `vanguard` namespace with the label `role=backend`
 2. ANY pod in the `bastion` namespace (assuming `bastion` namespace has a label `kubernetes.io/metadata.name=bastion`).
 Deny all other ingress traffic to pods with `role=db`.
@@ -386,6 +415,7 @@ Save the manifest to `./exam/course/17/netpol.yaml`.
 | **File to create** | `./exam/course/18/ingress.yaml` |
 
 ### Task
+
 An Ingress named `main-ingress` exists in the `sentinel` namespace, routing traffic for `sentinel.dojo.com` to `main-svc`.
 Create a new Ingress named `canary-ingress` in the `sentinel` namespace.
 Configure it as a canary release routing 20% of traffic to a service named `canary-svc` (which you don't need to create) on port 80.
@@ -407,6 +437,7 @@ Save the manifest to `./exam/course/18/ingress.yaml`.
 | **File to create** | `./exam/course/19/manual-svc.yaml` |
 
 ### Task
+
 Create a Service named `external-db` in the `outpost` namespace.
 It should NOT use a label selector.
 Configure it to expose TCP port `3306`.
@@ -427,6 +458,7 @@ Save the manifests to `./exam/course/19/manual-svc.yaml`.
 | **File to create** | `./exam/course/20/coredns.yaml` |
 
 ### Task
+
 Investigate the `coredns` ConfigMap in the `kube-system` namespace.
 You need to add a custom DNS rewrite rule.
 Modify the `coredns` ConfigMap so that any DNS query for `hachiman.local` is rewritten to `hachiman.garrison.svc.cluster.local`.

--- a/exams/ckad-simulation17/scoring-functions.sh
+++ b/exams/ckad-simulation17/scoring-functions.sh
@@ -2,556 +2,556 @@
 # CKAD Simulation 17 - Scoring Functions
 # Total Points: 116
 
-SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 source "$SCRIPT_DIR/../../scripts/lib/common.sh" 2>/dev/null || true
 
 EXAM_DIR="./exam/course"
 
 score_q1() {
-    local score=0
-    local max_points=5
-    local details=""
+	local score=0
+	local max_points=5
+	local details=""
 
-    if resource_exists pod entry-override fortress; then
-        ((score+=1))
-        details+="Pod exists. "
-        
-        local image=$(kubectl get pod entry-override -n fortress -o jsonpath='{.spec.containers[0].image}')
-        if [[ "$image" == "nginx:alpine" ]]; then
-            ((score+=1))
-            details+="Image correct. "
-        fi
-        
-        local cmd=$(kubectl get pod entry-override -n fortress -o jsonpath='{.spec.containers[0].command[0]}')
-        if [[ "$cmd" == "sleep" ]]; then
-            ((score+=2))
-            details+="Command overridden correctly. "
-        fi
-        
-        local arg=$(kubectl get pod entry-override -n fortress -o jsonpath='{.spec.containers[0].args[0]}')
-        if [[ "$arg" == "3600" ]]; then
-            ((score+=1))
-            details+="Args overridden correctly. "
-        fi
-    else
-        details+="Pod entry-override not found. "
-    fi
+	if resource_exists pod entry-override fortress; then
+		((score += 1))
+		details+="Pod exists. "
 
-    echo "$score/$max_points"
-    echo "DETAILS:$details"
+		local image=$(kubectl get pod entry-override -n fortress -o jsonpath='{.spec.containers[0].image}')
+		if [[ "$image" == "nginx:alpine" ]]; then
+			((score += 1))
+			details+="Image correct. "
+		fi
+
+		local cmd=$(kubectl get pod entry-override -n fortress -o jsonpath='{.spec.containers[0].command[0]}')
+		if [[ "$cmd" == "sleep" ]]; then
+			((score += 2))
+			details+="Command overridden correctly. "
+		fi
+
+		local arg=$(kubectl get pod entry-override -n fortress -o jsonpath='{.spec.containers[0].args[0]}')
+		if [[ "$arg" == "3600" ]]; then
+			((score += 1))
+			details+="Args overridden correctly. "
+		fi
+	else
+		details+="Pod entry-override not found. "
+	fi
+
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q2() {
-    local score=0
-    local max_points=5
-    local details=""
+	local score=0
+	local max_points=5
+	local details=""
 
-    if resource_exists configmap init-script-cm fortress; then
-        ((score+=1))
-        details+="ConfigMap exists. "
-    else
-        details+="ConfigMap not found. "
-    fi
+	if resource_exists configmap init-script-cm fortress; then
+		((score += 1))
+		details+="ConfigMap exists. "
+	else
+		details+="ConfigMap not found. "
+	fi
 
-    if resource_exists pod web-setup fortress; then
-        ((score+=1))
-        details+="Pod exists. "
-        
-        local init_image=$(kubectl get pod web-setup -n fortress -o jsonpath='{.spec.initContainers[0].image}')
-        if [[ "$init_image" == "busybox:1.36" ]]; then
-            ((score+=1))
-            details+="Init container image correct. "
-        fi
-        
-        local main_vol=$(kubectl get pod web-setup -n fortress -o jsonpath='{.spec.containers[0].volumeMounts[?(@.name=="work-vol")].mountPath}')
-        if [[ "$main_vol" == "/usr/share/nginx/html" ]]; then
-            ((score+=2))
-            details+="Volumes mounted correctly. "
-        fi
-    else
-        details+="Pod web-setup not found. "
-    fi
+	if resource_exists pod web-setup fortress; then
+		((score += 1))
+		details+="Pod exists. "
 
-    echo "$score/$max_points"
-    echo "DETAILS:$details"
+		local init_image=$(kubectl get pod web-setup -n fortress -o jsonpath='{.spec.initContainers[0].image}')
+		if [[ "$init_image" == "busybox:1.36" ]]; then
+			((score += 1))
+			details+="Init container image correct. "
+		fi
+
+		local main_vol=$(kubectl get pod web-setup -n fortress -o jsonpath='{.spec.containers[0].volumeMounts[?(@.name=="work-vol")].mountPath}')
+		if [[ "$main_vol" == "/usr/share/nginx/html" ]]; then
+			((score += 2))
+			details+="Volumes mounted correctly. "
+		fi
+	else
+		details+="Pod web-setup not found. "
+	fi
+
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q3() {
-    local score=0
-    local max_points=5
-    local details=""
+	local score=0
+	local max_points=5
+	local details=""
 
-    if resource_exists cronjob siege-report siege; then
-        ((score+=1))
-        details+="CronJob exists. "
-        
-        local schedule=$(kubectl get cj siege-report -n siege -o jsonpath='{.spec.schedule}')
-        if [[ "$schedule" == "30 * * * *" ]]; then
-            ((score+=2))
-            details+="Schedule correct. "
-        fi
-        
-        local tz=$(kubectl get cj siege-report -n siege -o jsonpath='{.spec.timeZone}')
-        if [[ "$tz" == "Asia/Tokyo" ]]; then
-            ((score+=2))
-            details+="Timezone correct. "
-        fi
-    else
-        details+="CronJob siege-report not found. "
-    fi
+	if resource_exists cronjob siege-report siege; then
+		((score += 1))
+		details+="CronJob exists. "
 
-    echo "$score/$max_points"
-    echo "DETAILS:$details"
+		local schedule=$(kubectl get cj siege-report -n siege -o jsonpath='{.spec.schedule}')
+		if [[ "$schedule" == "30 * * * *" ]]; then
+			((score += 2))
+			details+="Schedule correct. "
+		fi
+
+		local tz=$(kubectl get cj siege-report -n siege -o jsonpath='{.spec.timeZone}')
+		if [[ "$tz" == "Asia/Tokyo" ]]; then
+			((score += 2))
+			details+="Timezone correct. "
+		fi
+	else
+		details+="CronJob siege-report not found. "
+	fi
+
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q4() {
-    local score=0
-    local max_points=8
-    local details=""
+	local score=0
+	local max_points=8
+	local details=""
 
-    if resource_exists pod process-monitor bastion; then
-        ((score+=2))
-        details+="Pod exists. "
-        
-        local share_pid=$(kubectl get pod process-monitor -n bastion -o jsonpath='{.spec.shareProcessNamespace}')
-        if [[ "$share_pid" == "true" ]]; then
-            ((score+=3))
-            details+="shareProcessNamespace is true. "
-        fi
-        
-        local container_count=$(kubectl get pod process-monitor -n bastion -o jsonpath='{range .spec.containers[*]}{.name}{"\n"}{end}' | wc -l)
-        if [[ "$container_count" -eq 2 ]]; then
-            ((score+=3))
-            details+="Two containers exist. "
-        fi
-    else
-        details+="Pod process-monitor not found. "
-    fi
+	if resource_exists pod process-monitor bastion; then
+		((score += 2))
+		details+="Pod exists. "
 
-    echo "$score/$max_points"
-    echo "DETAILS:$details"
+		local share_pid=$(kubectl get pod process-monitor -n bastion -o jsonpath='{.spec.shareProcessNamespace}')
+		if [[ "$share_pid" == "true" ]]; then
+			((score += 3))
+			details+="shareProcessNamespace is true. "
+		fi
+
+		local container_count=$(kubectl get pod process-monitor -n bastion -o jsonpath='{range .spec.containers[*]}{.name}{"\n"}{end}' | wc -l)
+		if [[ "$container_count" -eq 2 ]]; then
+			((score += 3))
+			details+="Two containers exist. "
+		fi
+	else
+		details+="Pod process-monitor not found. "
+	fi
+
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q5() {
-    local score=0
-    local max_points=5
-    local details=""
+	local score=0
+	local max_points=5
+	local details=""
 
-    local release_status=$(helm status battle-web -n garrison -o json 2>/dev/null | grep -i deployed)
-    if [[ -n "$release_status" ]]; then
-        ((score+=2))
-        details+="Helm release is deployed. "
-        
-        local replicas=$(kubectl get deploy battle-web-battle-chart -n garrison -o jsonpath='{.spec.replicas}' 2>/dev/null)
-        if [[ "$replicas" == "3" ]]; then
-            ((score+=3))
-            details+="ReplicaCount is 3. "
-        else
-            details+="ReplicaCount is not 3. "
-        fi
-    else
-        details+="Helm release not deployed or failed. "
-    fi
+	local release_status=$(helm status battle-web -n garrison -o json 2>/dev/null | grep -i deployed)
+	if [[ -n "$release_status" ]]; then
+		((score += 2))
+		details+="Helm release is deployed. "
 
-    echo "$score/$max_points"
-    echo "DETAILS:$details"
+		local replicas=$(kubectl get deploy battle-web-battle-chart -n garrison -o jsonpath='{.spec.replicas}' 2>/dev/null)
+		if [[ "$replicas" == "3" ]]; then
+			((score += 3))
+			details+="ReplicaCount is 3. "
+		else
+			details+="ReplicaCount is not 3. "
+		fi
+	else
+		details+="Helm release not deployed or failed. "
+	fi
+
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q6() {
-    local score=0
-    local max_points=6
-    local details=""
+	local score=0
+	local max_points=6
+	local details=""
 
-    if resource_exists deployment citadel-guard citadel; then
-        ((score+=2))
-        details+="Deployment exists. "
-        
-        local pds=$(kubectl get deploy citadel-guard -n citadel -o jsonpath='{.spec.progressDeadlineSeconds}')
-        if [[ "$pds" == "15" ]]; then
-            ((score+=4))
-            details+="progressDeadlineSeconds is 15. "
-        else
-            details+="progressDeadlineSeconds is not 15. "
-        fi
-    else
-        details+="Deployment not found. "
-    fi
+	if resource_exists deployment citadel-guard citadel; then
+		((score += 2))
+		details+="Deployment exists. "
 
-    echo "$score/$max_points"
-    echo "DETAILS:$details"
+		local pds=$(kubectl get deploy citadel-guard -n citadel -o jsonpath='{.spec.progressDeadlineSeconds}')
+		if [[ "$pds" == "15" ]]; then
+			((score += 4))
+			details+="progressDeadlineSeconds is 15. "
+		else
+			details+="progressDeadlineSeconds is not 15. "
+		fi
+	else
+		details+="Deployment not found. "
+	fi
+
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q7() {
-    local score=0
-    local max_points=6
-    local details=""
+	local score=0
+	local max_points=6
+	local details=""
 
-    if resource_exists deployment api-server-green rampart; then
-        ((score+=2))
-        details+="Green deployment exists. "
-        
-        local svc_selector=$(kubectl get svc api-svc -n rampart -o jsonpath='{.spec.selector.app}')
-        if [[ "$svc_selector" == "api-server-green" ]]; then
-            ((score+=4))
-            details+="Service routes to green deployment. "
-        else
-            details+="Service selector is incorrect. "
-        fi
-    else
-        details+="Green deployment not found. "
-    fi
+	if resource_exists deployment api-server-green rampart; then
+		((score += 2))
+		details+="Green deployment exists. "
 
-    echo "$score/$max_points"
-    echo "DETAILS:$details"
+		local svc_selector=$(kubectl get svc api-svc -n rampart -o jsonpath='{.spec.selector.app}')
+		if [[ "$svc_selector" == "api-server-green" ]]; then
+			((score += 4))
+			details+="Service routes to green deployment. "
+		else
+			details+="Service selector is incorrect. "
+		fi
+	else
+		details+="Green deployment not found. "
+	fi
+
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q8() {
-    local score=0
-    local max_points=6
-    local details=""
+	local score=0
+	local max_points=6
+	local details=""
 
-    if resource_exists deployment vanguard-web vanguard; then
-        ((score+=1))
-        details+="Deployment exists. "
-        
-        local image=$(kubectl get deploy vanguard-web -n vanguard -o jsonpath='{.spec.template.spec.containers[0].image}')
-        if [[ "$image" == "nginx:1.23.0-alpine" ]]; then
-            ((score+=3))
-            details+="Image updated via Kustomize. "
-        fi
-        
-        local replicas=$(kubectl get deploy vanguard-web -n vanguard -o jsonpath='{.spec.replicas}')
-        if [[ "$replicas" == "5" ]]; then
-            ((score+=2))
-            details+="Replicas scaled to 5. "
-        fi
-    else
-        details+="Deployment vanguard-web not found. "
-    fi
+	if resource_exists deployment vanguard-web vanguard; then
+		((score += 1))
+		details+="Deployment exists. "
 
-    echo "$score/$max_points"
-    echo "DETAILS:$details"
+		local image=$(kubectl get deploy vanguard-web -n vanguard -o jsonpath='{.spec.template.spec.containers[0].image}')
+		if [[ "$image" == "nginx:1.23.0-alpine" ]]; then
+			((score += 3))
+			details+="Image updated via Kustomize. "
+		fi
+
+		local replicas=$(kubectl get deploy vanguard-web -n vanguard -o jsonpath='{.spec.replicas}')
+		if [[ "$replicas" == "5" ]]; then
+			((score += 2))
+			details+="Replicas scaled to 5. "
+		fi
+	else
+		details+="Deployment vanguard-web not found. "
+	fi
+
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q9() {
-    local score=0
-    local max_points=5
-    local details=""
+	local score=0
+	local max_points=5
+	local details=""
 
-    if resource_exists pod data-processor sentinel; then
-        local status=$(kubectl get pod data-processor -n sentinel -o jsonpath='{.status.phase}')
-        if [[ "$status" == "Running" ]]; then
-            ((score+=2))
-            details+="Pod is running. "
-        fi
-        
-        local mem_limit=$(kubectl get pod data-processor -n sentinel -o jsonpath='{.spec.containers[0].resources.limits.memory}')
-        if [[ "$mem_limit" == "256Mi" ]]; then
-            ((score+=3))
-            details+="Memory limit is 256Mi. "
-        fi
-    else
-        details+="Pod data-processor not found. "
-    fi
+	if resource_exists pod data-processor sentinel; then
+		local status=$(kubectl get pod data-processor -n sentinel -o jsonpath='{.status.phase}')
+		if [[ "$status" == "Running" ]]; then
+			((score += 2))
+			details+="Pod is running. "
+		fi
 
-    echo "$score/$max_points"
-    echo "DETAILS:$details"
+		local mem_limit=$(kubectl get pod data-processor -n sentinel -o jsonpath='{.spec.containers[0].resources.limits.memory}')
+		if [[ "$mem_limit" == "256Mi" ]]; then
+			((score += 3))
+			details+="Memory limit is 256Mi. "
+		fi
+	else
+		details+="Pod data-processor not found. "
+	fi
+
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q10() {
-    local score=0
-    local max_points=6
-    local details=""
+	local score=0
+	local max_points=6
+	local details=""
 
-    if resource_exists pod secure-app outpost; then
-        local ephem_count=$(kubectl get pod secure-app -n outpost -o jsonpath='{range .spec.ephemeralContainers[*]}{.name}{"\n"}{end}' | wc -l)
-        if [[ "$ephem_count" -ge 1 ]]; then
-            ((score+=3))
-            details+="Ephemeral container exists. "
-            
-            local ephem_name=$(kubectl get pod secure-app -n outpost -o jsonpath='{.spec.ephemeralContainers[0].name}')
-            if [[ "$ephem_name" == "debugger" ]]; then
-                ((score+=3))
-                details+="Ephemeral container named debugger. "
-            fi
-        else
-            details+="No ephemeral container found. "
-        fi
-    else
-        details+="Pod secure-app not found. "
-    fi
+	if resource_exists pod secure-app outpost; then
+		local ephem_count=$(kubectl get pod secure-app -n outpost -o jsonpath='{range .spec.ephemeralContainers[*]}{.name}{"\n"}{end}' | wc -l)
+		if [[ "$ephem_count" -ge 1 ]]; then
+			((score += 3))
+			details+="Ephemeral container exists. "
 
-    echo "$score/$max_points"
-    echo "DETAILS:$details"
+			local ephem_name=$(kubectl get pod secure-app -n outpost -o jsonpath='{.spec.ephemeralContainers[0].name}')
+			if [[ "$ephem_name" == "debugger" ]]; then
+				((score += 3))
+				details+="Ephemeral container named debugger. "
+			fi
+		else
+			details+="No ephemeral container found. "
+		fi
+	else
+		details+="Pod secure-app not found. "
+	fi
+
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q11() {
-    local score=0
-    local max_points=7
-    local details=""
+	local score=0
+	local max_points=7
+	local details=""
 
-    if resource_exists deployment weapon-smith armory; then
-        local replicas=$(kubectl get deploy weapon-smith -n armory -o jsonpath='{.spec.replicas}')
-        if [[ "$replicas" == "3" ]]; then
-            ((score+=3))
-            details+="Replicas is 3. "
-        fi
-        
-        local cpu_req=$(kubectl get deploy weapon-smith -n armory -o jsonpath='{.spec.template.spec.containers[0].resources.requests.cpu}')
-        local mem_req=$(kubectl get deploy weapon-smith -n armory -o jsonpath='{.spec.template.spec.containers[0].resources.requests.memory}')
-        
-        if [[ "$cpu_req" == "100m" && "$mem_req" == "128Mi" ]]; then
-            ((score+=4))
-            details+="Requests are correct. "
-        fi
-    else
-        details+="Deployment weapon-smith not found. "
-    fi
+	if resource_exists deployment weapon-smith armory; then
+		local replicas=$(kubectl get deploy weapon-smith -n armory -o jsonpath='{.spec.replicas}')
+		if [[ "$replicas" == "3" ]]; then
+			((score += 3))
+			details+="Replicas is 3. "
+		fi
 
-    echo "$score/$max_points"
-    echo "DETAILS:$details"
+		local cpu_req=$(kubectl get deploy weapon-smith -n armory -o jsonpath='{.spec.template.spec.containers[0].resources.requests.cpu}')
+		local mem_req=$(kubectl get deploy weapon-smith -n armory -o jsonpath='{.spec.template.spec.containers[0].resources.requests.memory}')
+
+		if [[ "$cpu_req" == "100m" && "$mem_req" == "128Mi" ]]; then
+			((score += 4))
+			details+="Requests are correct. "
+		fi
+	else
+		details+="Deployment weapon-smith not found. "
+	fi
+
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q12() {
-    local score=0
-    local max_points=5
-    local details=""
+	local score=0
+	local max_points=5
+	local details=""
 
-    if resource_exists pod resource-aware fortress; then
-        ((score+=1))
-        details+="Pod exists. "
-        
-        local env_cpu=$(kubectl get pod resource-aware -n fortress -o jsonpath='{.spec.containers[0].env[?(@.name=="MY_CPU_REQUEST")].valueFrom.resourceFieldRef.resource}')
-        if [[ "$env_cpu" == "requests.cpu" ]]; then
-            ((score+=2))
-            details+="MY_CPU_REQUEST mapped correctly. "
-        fi
-        
-        local env_mem=$(kubectl get pod resource-aware -n fortress -o jsonpath='{.spec.containers[0].env[?(@.name=="MY_MEM_LIMIT")].valueFrom.resourceFieldRef.resource}')
-        if [[ "$env_mem" == "limits.memory" ]]; then
-            ((score+=2))
-            details+="MY_MEM_LIMIT mapped correctly. "
-        fi
-    else
-        details+="Pod resource-aware not found. "
-    fi
+	if resource_exists pod resource-aware fortress; then
+		((score += 1))
+		details+="Pod exists. "
 
-    echo "$score/$max_points"
-    echo "DETAILS:$details"
+		local env_cpu=$(kubectl get pod resource-aware -n fortress -o jsonpath='{.spec.containers[0].env[?(@.name=="MY_CPU_REQUEST")].valueFrom.resourceFieldRef.resource}')
+		if [[ "$env_cpu" == "requests.cpu" ]]; then
+			((score += 2))
+			details+="MY_CPU_REQUEST mapped correctly. "
+		fi
+
+		local env_mem=$(kubectl get pod resource-aware -n fortress -o jsonpath='{.spec.containers[0].env[?(@.name=="MY_MEM_LIMIT")].valueFrom.resourceFieldRef.resource}')
+		if [[ "$env_mem" == "limits.memory" ]]; then
+			((score += 2))
+			details+="MY_MEM_LIMIT mapped correctly. "
+		fi
+	else
+		details+="Pod resource-aware not found. "
+	fi
+
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q13() {
-    local score=0
-    local max_points=6
-    local details=""
+	local score=0
+	local max_points=6
+	local details=""
 
-    if resource_exists serviceaccount stealth-sa siege; then
-        ((score+=1))
-        details+="SA exists. "
-    fi
-    
-    if resource_exists pod stealth-pod siege; then
-        ((score+=1))
-        details+="Pod exists. "
-        
-        local automount=$(kubectl get pod stealth-pod -n siege -o jsonpath='{.spec.automountServiceAccountToken}')
-        if [[ "$automount" == "false" ]]; then
-            ((score+=2))
-            details+="Automount disabled. "
-        fi
-        
-        local volume_mount=$(kubectl get pod stealth-pod -n siege -o jsonpath='{.spec.containers[0].volumeMounts[?(@.mountPath=="/var/run/secrets/custom-token")].name}')
-        if [[ -n "$volume_mount" ]]; then
-            ((score+=2))
-            details+="Token mounted manually. "
-        fi
-    fi
+	if resource_exists serviceaccount stealth-sa siege; then
+		((score += 1))
+		details+="SA exists. "
+	fi
 
-    echo "$score/$max_points"
-    echo "DETAILS:$details"
+	if resource_exists pod stealth-pod siege; then
+		((score += 1))
+		details+="Pod exists. "
+
+		local automount=$(kubectl get pod stealth-pod -n siege -o jsonpath='{.spec.automountServiceAccountToken}')
+		if [[ "$automount" == "false" ]]; then
+			((score += 2))
+			details+="Automount disabled. "
+		fi
+
+		local volume_mount=$(kubectl get pod stealth-pod -n siege -o jsonpath='{.spec.containers[0].volumeMounts[?(@.mountPath=="/var/run/secrets/custom-token")].name}')
+		if [[ -n "$volume_mount" ]]; then
+			((score += 2))
+			details+="Token mounted manually. "
+		fi
+	fi
+
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q14() {
-    local score=0
-    local max_points=5
-    local details=""
+	local score=0
+	local max_points=5
+	local details=""
 
-    if resource_exists pod secure-workload bastion; then
-        ((score+=1))
-        details+="Pod exists. "
-        
-        local non_root=$(kubectl get pod secure-workload -n bastion -o jsonpath='{.spec.securityContext.runAsNonRoot}')
-        if [[ "$non_root" == "true" ]]; then
-            ((score+=2))
-            details+="runAsNonRoot is true. "
-        fi
-        
-        local seccomp=$(kubectl get pod secure-workload -n bastion -o jsonpath='{.spec.securityContext.seccompProfile.type}')
-        if [[ "$seccomp" == "RuntimeDefault" ]]; then
-            ((score+=2))
-            details+="seccompProfile is RuntimeDefault. "
-        fi
-    else
-        details+="Pod secure-workload not found. "
-    fi
+	if resource_exists pod secure-workload bastion; then
+		((score += 1))
+		details+="Pod exists. "
 
-    echo "$score/$max_points"
-    echo "DETAILS:$details"
+		local non_root=$(kubectl get pod secure-workload -n bastion -o jsonpath='{.spec.securityContext.runAsNonRoot}')
+		if [[ "$non_root" == "true" ]]; then
+			((score += 2))
+			details+="runAsNonRoot is true. "
+		fi
+
+		local seccomp=$(kubectl get pod secure-workload -n bastion -o jsonpath='{.spec.securityContext.seccompProfile.type}')
+		if [[ "$seccomp" == "RuntimeDefault" ]]; then
+			((score += 2))
+			details+="seccompProfile is RuntimeDefault. "
+		fi
+	else
+		details+="Pod secure-workload not found. "
+	fi
+
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q15() {
-    local score=0
-    local max_points=7
-    local details=""
+	local score=0
+	local max_points=7
+	local details=""
 
-    if resource_exists secret db-credentials citadel; then
-        ((score+=2))
-        details+="Secret exists. "
-    fi
-    
-    if resource_exists pod db-consumer citadel; then
-        ((score+=1))
-        details+="Pod exists. "
-        
-        local item_key=$(kubectl get pod db-consumer -n citadel -o jsonpath='{.spec.volumes[?(@.secret.secretName=="db-credentials")].secret.items[0].key}')
-        local item_path=$(kubectl get pod db-consumer -n citadel -o jsonpath='{.spec.volumes[?(@.secret.secretName=="db-credentials")].secret.items[0].path}')
-        
-        if [[ "$item_key" == "password" && "$item_path" == "db-pass.txt" ]]; then
-            ((score+=4))
-            details+="Specific secret key mounted correctly. "
-        else
-            details+="Secret keys not mounted correctly. "
-        fi
-    else
-        details+="Pod db-consumer not found. "
-    fi
+	if resource_exists secret db-credentials citadel; then
+		((score += 2))
+		details+="Secret exists. "
+	fi
 
-    echo "$score/$max_points"
-    echo "DETAILS:$details"
+	if resource_exists pod db-consumer citadel; then
+		((score += 1))
+		details+="Pod exists. "
+
+		local item_key=$(kubectl get pod db-consumer -n citadel -o jsonpath='{.spec.volumes[?(@.secret.secretName=="db-credentials")].secret.items[0].key}')
+		local item_path=$(kubectl get pod db-consumer -n citadel -o jsonpath='{.spec.volumes[?(@.secret.secretName=="db-credentials")].secret.items[0].path}')
+
+		if [[ "$item_key" == "password" && "$item_path" == "db-pass.txt" ]]; then
+			((score += 4))
+			details+="Specific secret key mounted correctly. "
+		else
+			details+="Secret keys not mounted correctly. "
+		fi
+	else
+		details+="Pod db-consumer not found. "
+	fi
+
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q16() {
-    local score=0
-    local max_points=6
-    local details=""
+	local score=0
+	local max_points=6
+	local details=""
 
-    if resource_exists limitrange rampart-limits rampart; then
-        ((score+=3))
-        details+="LimitRange exists. "
-    fi
-    
-    if resource_exists pod default-pod rampart; then
-        local pod_mem_req=$(kubectl get pod default-pod -n rampart -o jsonpath='{.spec.containers[0].resources.requests.memory}')
-        if [[ "$pod_mem_req" == "256Mi" ]]; then
-            ((score+=3))
-            details+="Pod inherited default requests. "
-        fi
-    fi
+	if resource_exists limitrange rampart-limits rampart; then
+		((score += 3))
+		details+="LimitRange exists. "
+	fi
 
-    echo "$score/$max_points"
-    echo "DETAILS:$details"
+	if resource_exists pod default-pod rampart; then
+		local pod_mem_req=$(kubectl get pod default-pod -n rampart -o jsonpath='{.spec.containers[0].resources.requests.memory}')
+		if [[ "$pod_mem_req" == "256Mi" ]]; then
+			((score += 3))
+			details+="Pod inherited default requests. "
+		fi
+	fi
+
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q17() {
-    local score=0
-    local max_points=7
-    local details=""
+	local score=0
+	local max_points=7
+	local details=""
 
-    if resource_exists networkpolicy protect-db vanguard; then
-        ((score+=2))
-        details+="NetPol exists. "
-        
-        local ports=$(kubectl get netpol protect-db -n vanguard -o jsonpath='{.spec.ingress[*].ports[*].port}')
-        if [[ "$ports" == *"5432"* ]]; then
-            ((score+=2))
-            details+="Port 5432 allowed. "
-        fi
-        
-        local namespace_selector=$(kubectl get netpol protect-db -n vanguard -o jsonpath='{.spec.ingress[*].from[*].namespaceSelector.matchLabels}')
-        if [[ "$namespace_selector" == *"kubernetes.io/metadata.name"* ]]; then
-            ((score+=3))
-            details+="Namespace selector used correctly. "
-        fi
-    else
-        details+="NetPol protect-db not found. "
-    fi
+	if resource_exists networkpolicy protect-db vanguard; then
+		((score += 2))
+		details+="NetPol exists. "
 
-    echo "$score/$max_points"
-    echo "DETAILS:$details"
+		local ports=$(kubectl get netpol protect-db -n vanguard -o jsonpath='{.spec.ingress[*].ports[*].port}')
+		if [[ "$ports" == *"5432"* ]]; then
+			((score += 2))
+			details+="Port 5432 allowed. "
+		fi
+
+		local namespace_selector=$(kubectl get netpol protect-db -n vanguard -o jsonpath='{.spec.ingress[*].from[*].namespaceSelector.matchLabels}')
+		if [[ "$namespace_selector" == *"kubernetes.io/metadata.name"* ]]; then
+			((score += 3))
+			details+="Namespace selector used correctly. "
+		fi
+	else
+		details+="NetPol protect-db not found. "
+	fi
+
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q18() {
-    local score=0
-    local max_points=6
-    local details=""
+	local score=0
+	local max_points=6
+	local details=""
 
-    if resource_exists ingress canary-ingress sentinel; then
-        ((score+=2))
-        details+="Canary ingress exists. "
-        
-        local weight=$(kubectl get ingress canary-ingress -n sentinel -o jsonpath='{.metadata.annotations.nginx\.ingress\.kubernetes\.io/canary-weight}')
-        if [[ "$weight" == "20" ]]; then
-            ((score+=4))
-            details+="Canary weight annotation is 20. "
-        else
-            details+="Canary weight annotation incorrect. "
-        fi
-    else
-        details+="Canary ingress not found. "
-    fi
+	if resource_exists ingress canary-ingress sentinel; then
+		((score += 2))
+		details+="Canary ingress exists. "
 
-    echo "$score/$max_points"
-    echo "DETAILS:$details"
+		local weight=$(kubectl get ingress canary-ingress -n sentinel -o jsonpath='{.metadata.annotations.nginx\.ingress\.kubernetes\.io/canary-weight}')
+		if [[ "$weight" == "20" ]]; then
+			((score += 4))
+			details+="Canary weight annotation is 20. "
+		else
+			details+="Canary weight annotation incorrect. "
+		fi
+	else
+		details+="Canary ingress not found. "
+	fi
+
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q19() {
-    local score=0
-    local max_points=6
-    local details=""
+	local score=0
+	local max_points=6
+	local details=""
 
-    if resource_exists service external-db outpost; then
-        ((score+=2))
-        details+="Service exists. "
-        
-        local selector=$(kubectl get svc external-db -n outpost -o jsonpath='{.spec.selector}')
-        if [[ -z "$selector" || "$selector" == "{}" ]]; then
-            ((score+=2))
-            details+="Service has no selector. "
-        fi
-    fi
-    
-    if resource_exists endpoints external-db outpost; then
-        local ip=$(kubectl get endpoints external-db -n outpost -o jsonpath='{.subsets[0].addresses[0].ip}')
-        if [[ "$ip" == "10.50.50.50" ]]; then
-            ((score+=2))
-            details+="Endpoints mapped to correct IP. "
-        fi
-    fi
+	if resource_exists service external-db outpost; then
+		((score += 2))
+		details+="Service exists. "
 
-    echo "$score/$max_points"
-    echo "DETAILS:$details"
+		local selector=$(kubectl get svc external-db -n outpost -o jsonpath='{.spec.selector}')
+		if [[ -z "$selector" || "$selector" == "{}" ]]; then
+			((score += 2))
+			details+="Service has no selector. "
+		fi
+	fi
+
+	if resource_exists endpoints external-db outpost; then
+		local ip=$(kubectl get endpoints external-db -n outpost -o jsonpath='{.subsets[0].addresses[0].ip}')
+		if [[ "$ip" == "10.50.50.50" ]]; then
+			((score += 2))
+			details+="Endpoints mapped to correct IP. "
+		fi
+	fi
+
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q20() {
-    local score=0
-    local max_points=7
-    local details=""
+	local score=0
+	local max_points=7
+	local details=""
 
-    if [[ -f "./exam/course/20/coredns.yaml" ]]; then
-        ((score+=2))
-        details+="coredns.yaml exists. "
-        
-        local file_content=$(cat ./exam/course/20/coredns.yaml)
-        if [[ "$file_content" == *"rewrite name exact hachiman.local hachiman.garrison.svc.cluster.local"* ]]; then
-            ((score+=5))
-            details+="Rewrite rule present. "
-        else
-            details+="Rewrite rule not found. "
-        fi
-    else
-        details+="File ./exam/course/20/coredns.yaml not found. "
-    fi
+	if [[ -f "./exam/course/20/coredns.yaml" ]]; then
+		((score += 2))
+		details+="coredns.yaml exists. "
 
-    echo "$score/$max_points"
-    echo "DETAILS:$details"
+		local file_content=$(cat ./exam/course/20/coredns.yaml)
+		if [[ "$file_content" == *"rewrite name exact hachiman.local hachiman.garrison.svc.cluster.local"* ]]; then
+			((score += 5))
+			details+="Rewrite rule present. "
+		else
+			details+="Rewrite rule not found. "
+		fi
+	else
+		details+="File ./exam/course/20/coredns.yaml not found. "
+	fi
+
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }

--- a/exams/ckad-simulation17/solutions.md
+++ b/exams/ckad-simulation17/solutions.md
@@ -115,6 +115,7 @@ patches:
         path: /spec/replicas
         value: 5
 ```
+
 ```bash
 kubectl kustomize ./exam/course/8/ > ./exam/course/8/kustomize-output.yaml
 kubectl apply -f ./exam/course/8/kustomize-output.yaml -n vanguard

--- a/exams/ckad-simulation18/post-setup.sh
+++ b/exams/ckad-simulation18/post-setup.sh
@@ -3,31 +3,31 @@
 # Post-setup for CKAD Simulation 18
 
 exam_post_setup() {
-  local exam_dir=$1
-  
-  # Install genesis-web helm chart in nexus namespace
-  echo "Installing genesis-web Helm chart..."
-  helm install genesis-web "./exams/ckad-simulation18/templates/5/genesis-web-chart" -n nexus --set customLabel="initial-install" --wait
+	local exam_dir=$1
 
-  # === Auto-generated starter files ===
-  local BASE_DIR="./exam/course"
-  mkdir -p "$BASE_DIR/1" "$BASE_DIR/5" "$BASE_DIR/8" "$BASE_DIR/10" "$BASE_DIR/11" "$BASE_DIR/19"
-  
-  cat << 'EOF_D' > "$BASE_DIR/1/Dockerfile"
+	# Install genesis-web helm chart in nexus namespace
+	echo "Installing genesis-web Helm chart..."
+	helm install genesis-web "./exams/ckad-simulation18/templates/5/genesis-web-chart" -n nexus --set customLabel="initial-install" --wait
+
+	# === Auto-generated starter files ===
+	local BASE_DIR="./exam/course"
+	mkdir -p "$BASE_DIR/1" "$BASE_DIR/5" "$BASE_DIR/8" "$BASE_DIR/10" "$BASE_DIR/11" "$BASE_DIR/19"
+
+	cat <<'EOF_D' >"$BASE_DIR/1/Dockerfile"
 FROM nginx:alpine
 # TODO: Complete this manifest per the task instructions
 EOF_D
 
-  cp -r "./exams/ckad-simulation18/templates/5/genesis-web-chart" "$BASE_DIR/5/"
+	cp -r "./exams/ckad-simulation18/templates/5/genesis-web-chart" "$BASE_DIR/5/"
 
-  mkdir -p "$BASE_DIR/8/kustomize"
-  cat << 'EOF_K' > "$BASE_DIR/8/kustomize/kustomization.yaml"
+	mkdir -p "$BASE_DIR/8/kustomize"
+	cat <<'EOF_K' >"$BASE_DIR/8/kustomize/kustomization.yaml"
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - deployment.yaml
 EOF_K
-  cat << 'EOF_K2' > "$BASE_DIR/8/kustomize/deployment.yaml"
+	cat <<'EOF_K2' >"$BASE_DIR/8/kustomize/deployment.yaml"
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -40,14 +40,13 @@ spec:
         image: nginx
 EOF_K2
 
-  
-  cat << 'EOF_S' > "$BASE_DIR/11/check.sh"
+	cat <<'EOF_S' >"$BASE_DIR/11/check.sh"
 #!/bin/bash
 # TODO: Complete this script per the task instructions
 EOF_S
-  chmod +x "$BASE_DIR/11/check.sh"
-  
-  touch "$BASE_DIR/11/health.log"
+	chmod +x "$BASE_DIR/11/check.sh"
 
-  return 0
+	touch "$BASE_DIR/11/health.log"
+
+	return 0
 }

--- a/exams/ckad-simulation18/questions.md
+++ b/exams/ckad-simulation18/questions.md
@@ -27,6 +27,7 @@
 ### Task
 
 There is a skeleton Dockerfile located at `./exam/course/1/Dockerfile`.
+
 1. Modify the `Dockerfile` to use a non-root user. Add an instruction to create a user named `izanagi` with UID `1000` and switch to this user.
 2. Build the Docker image from this `Dockerfile` and tag it as `localhost:5000/genesis-app:v1`.
 3. Push the image to the local registry at `localhost:5000`.
@@ -47,8 +48,9 @@ There is a skeleton Dockerfile located at `./exam/course/1/Dockerfile`.
 ### Task
 
 Create a Pod named `data-transformer` in the `origin` namespace implementing the Adapter pattern.
+
 - The Pod should have an `emptyDir` volume named `shared-data`.
-- Main container: 
+- Main container:
   - Name: `app-container`
   - Image: `busybox:1.32`
   - Command: `sh`, `-c`, `while true; do echo "$(date) - DATA" >> /var/log/app.log; sleep 5; done`
@@ -74,6 +76,7 @@ Create a Pod named `data-transformer` in the `origin` namespace implementing the
 ### Task
 
 Create a Job named `index-processor` in the `primal` namespace.
+
 - Configure it to use Indexed completion mode (`completionMode: Indexed`).
 - It should run a total of `5` completions.
 - It should run up to `2` pods in parallel.
@@ -94,6 +97,7 @@ Create a Job named `index-processor` in the `primal` namespace.
 ### Task
 
 Create a Pod named `graceful-shutdown` in the `ancient` namespace.
+
 - Image: `nginx:1.21`
 - Set the `terminationGracePeriodSeconds` to `45`.
 - Configure a `preStop` hook using `exec` that runs the command: `sh`, `-c`, `sleep 10 && nginx -s quit`
@@ -113,6 +117,7 @@ Create a Pod named `graceful-shutdown` in the `ancient` namespace.
 ### Task
 
 A Helm release named `genesis-web` is deployed in the `nexus` namespace.
+
 1. Inspect the chart values currently deployed.
 2. Upgrade the release to change the `replicaCount` to `3` without altering any other custom values that were previously set (use `--reuse-values`).
 3. You can find the chart source at `./exam/course/5/genesis-web-chart` if needed, but you only need to modify the deployed release.
@@ -150,6 +155,7 @@ A Helm release named `genesis-web` is deployed in the `nexus` namespace.
 ### Task
 
 A Deployment named `eden-api` exists in the `eden` namespace.
+
 1. Update the Deployment's image from `nginx:1.20` to `nginx:1.21`.
 2. Ensure that the change is recorded in the rollout history by setting the revision annotation on the Deployment resource.
 3. Ensure the Deployment uses a rolling update strategy with `maxSurge` set to `2` and `maxUnavailable` set to `0`.
@@ -169,6 +175,7 @@ A Deployment named `eden-api` exists in the `eden` namespace.
 ### Task
 
 In `./exam/course/8/kustomize`, there is a `kustomization.yaml` file.
+
 1. Add a `secretGenerator` to the `kustomization.yaml` to generate a secret named `matrix-secret`.
 2. The secret should contain a literal `db-password=supersecret`.
 3. Configure `generatorOptions` to disable the suffix hash (`disableNameSuffixHash: true`).
@@ -189,6 +196,7 @@ In `./exam/course/8/kustomize`, there is a `kustomization.yaml` file.
 ### Task
 
 A Pod named `stuck-pod` in the `cosmos` namespace is stuck in the `Init:Error` state.
+
 1. Identify the reason why the init container is failing.
 2. Fix the pod so that it reaches the `Running` state. You may recreate the pod if necessary. Note: The init container is supposed to successfully run a shell command and exit.
 
@@ -225,6 +233,7 @@ Ensure the output has the exact headers `TYPE`, `REASON`, and `MESSAGE`.
 ### Task
 
 There is a deployment `backend-api` in the `genesis` namespace that is exposing an API internally on port `8080`.
+
 1. Create a script at `./exam/course/11/check.sh` that sets up a temporary port-forwarding to the `backend-api` service on local port `9999` mapping to the service port `8080`.
 2. The script should use `curl` to fetch `http://localhost:9999/health`, append the output to `./exam/course/11/health.log`, and then terminate the port-forward process.
 
@@ -246,6 +255,7 @@ There is a deployment `backend-api` in the `genesis` namespace that is exposing 
 
 Create a Pod named `projected-pod` in the `origin` namespace using the `nginx:alpine` image.
 Use a single `projected` volume mounted at `/var/run/projected` to expose all of the following sources:
+
 1. A Secret named `my-secret` (already exists in the namespace) - expose the `username` key.
 2. A ConfigMap named `my-config` (already exists) - expose all its keys.
 3. DownwardAPI - expose the pod's `metadata.labels` as a file named `labels`.
@@ -266,6 +276,7 @@ Use a single `projected` volume mounted at `/var/run/projected` to expose all of
 ### Task
 
 Create a Secret named `static-creds` in the `primal` namespace.
+
 - It should contain the literal `api-key=12345ABC`.
 - Make the Secret immutable so its contents cannot be modified.
 
@@ -285,6 +296,7 @@ Create a Secret named `static-creds` in the `primal` namespace.
 
 Create a Pod named `secure-pod` in the `ancient` namespace using the `nginx:alpine` image.
 Configure the container's security context with the following hardening settings:
+
 - It must run as a non-root user (e.g., `runAsNonRoot: true`, `runAsUser: 1000`).
 - The root filesystem must be read-only.
 - Drop ALL capabilities.
@@ -306,6 +318,7 @@ Configure the container's security context with the following hardening settings
 ### Task
 
 Create a ClusterRole named `monitor-viewer`.
+
 1. It should have permissions to `get`, `list`, and `watch` all `pods` and `services` cluster-wide.
 2. Create another ClusterRole named `aggregated-monitor` that uses aggregation labels to automatically inherit the rules from `monitor-viewer`.
 3. Add the required label to `monitor-viewer` so it gets aggregated into `aggregated-monitor`.
@@ -325,6 +338,7 @@ Create a ClusterRole named `monitor-viewer`.
 ### Task
 
 Create a ResourceQuota named `priority-quota` in the `eden` namespace.
+
 1. Configure it to limit the total number of pods to `5` and total requests.cpu to `2`.
 2. Apply a scope selector so that this quota ONLY applies to Pods that have the `PriorityClass` of `high-priority` (assume such PriorityClass exists or match by `PriorityClassIn` scope selector). Use the scope `PriorityClassIn` with values `high-priority`.
 
@@ -343,6 +357,7 @@ Create a ResourceQuota named `priority-quota` in the `eden` namespace.
 ### Task
 
 Create a NetworkPolicy named `allow-named-port` in the `matrix` namespace.
+
 - It should apply to pods with the label `role=backend`.
 - It should allow incoming TCP traffic on the named port `api-port`.
 - It should only allow this traffic from pods in the `matrix` namespace with the label `role=frontend`.
@@ -399,6 +414,7 @@ Create a file at `./exam/course/19/fqdn.txt` containing the Fully Qualified Doma
 ### Task
 
 Create a NetworkPolicy named `isolate-namespace` in the `nexus` namespace.
+
 - It should apply to ALL pods in the `nexus` namespace.
 - It should allow all incoming traffic from pods within the `nexus` namespace.
 - It should explicitly block all incoming traffic from pods in ANY OTHER namespace.

--- a/exams/ckad-simulation18/scoring-functions.sh
+++ b/exams/ckad-simulation18/scoring-functions.sh
@@ -6,562 +6,562 @@ source "$SCRIPT_DIR/../../scripts/lib/common.sh" 2>/dev/null || true
 
 # Q1: 6 points
 score_q1() {
-  local score=0
-  local max_points=6
-  local details=""
+	local score=0
+	local max_points=6
+	local details=""
 
-  if docker image inspect localhost:5000/genesis-app:v1 >/dev/null 2>&1; then
-    score=$((score + 1))
-    details+="Image built and tagged. "
-    local user=$(docker image inspect localhost:5000/genesis-app:v1 | jq -r '.[0].Config.User')
-    if [[ "$user" == "1000" ]]; then
-      score=$((score + 2))
-      details+="USER 1000 instruction found. "
-    else
-      details+="USER 1000 instruction missing. "
-    fi
-  else
-    details+="Image localhost:5000/genesis-app:v1 not found locally. "
-  fi
+	if docker image inspect localhost:5000/genesis-app:v1 >/dev/null 2>&1; then
+		score=$((score + 1))
+		details+="Image built and tagged. "
+		local user=$(docker image inspect localhost:5000/genesis-app:v1 | jq -r '.[0].Config.User')
+		if [[ "$user" == "1000" ]]; then
+			score=$((score + 2))
+			details+="USER 1000 instruction found. "
+		else
+			details+="USER 1000 instruction missing. "
+		fi
+	else
+		details+="Image localhost:5000/genesis-app:v1 not found locally. "
+	fi
 
-  if resource_exists pod genesis-pod genesis; then
-    score=$((score + 1))
-    local image=$(kubectl get pod genesis-pod -n genesis -o jsonpath='{.spec.containers[0].image}')
-    if [[ "$image" == "localhost:5000/genesis-app:v1" ]]; then
-      score=$((score + 2))
-      details+="Pod uses correct image. "
-    else
-      details+="Pod uses wrong image. "
-    fi
-  else
-    details+="Pod genesis-pod not found. "
-  fi
+	if resource_exists pod genesis-pod genesis; then
+		score=$((score + 1))
+		local image=$(kubectl get pod genesis-pod -n genesis -o jsonpath='{.spec.containers[0].image}')
+		if [[ "$image" == "localhost:5000/genesis-app:v1" ]]; then
+			score=$((score + 2))
+			details+="Pod uses correct image. "
+		else
+			details+="Pod uses wrong image. "
+		fi
+	else
+		details+="Pod genesis-pod not found. "
+	fi
 
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 # Q2: 6 points
 score_q2() {
-  local score=0
-  local max_points=6
-  local details=""
+	local score=0
+	local max_points=6
+	local details=""
 
-  if resource_exists pod data-transformer origin; then
-    score=$((score + 2))
-    
-    local c_count=$(kubectl get pod data-transformer -n origin -o jsonpath='{.spec.containers[*].name}' | wc -w)
-    if [[ "$c_count" -ge 2 ]]; then
-      score=$((score + 1))
-      details+="Pod has 2 containers. "
-    fi
+	if resource_exists pod data-transformer origin; then
+		score=$((score + 2))
 
-    local vol=$(kubectl get pod data-transformer -n origin -o jsonpath='{.spec.volumes[?(@.name=="shared-data")].emptyDir}')
-    if [[ -n "$vol" ]]; then
-      score=$((score + 1))
-      details+="Shared emptyDir volume found. "
-    fi
+		local c_count=$(kubectl get pod data-transformer -n origin -o jsonpath='{.spec.containers[*].name}' | wc -w)
+		if [[ "$c_count" -ge 2 ]]; then
+			score=$((score + 1))
+			details+="Pod has 2 containers. "
+		fi
 
-    local vol_mounts=$(kubectl get pod data-transformer -n origin -o jsonpath='{.spec.containers[*].volumeMounts[?(@.name=="shared-data")].mountPath}')
-    if [[ "$vol_mounts" == *"/var/log"*"/var/log"* ]]; then
-      score=$((score + 2))
-      details+="Volume mounted in both containers. "
-    fi
-  else
-    details+="Pod data-transformer not found. "
-  fi
+		local vol=$(kubectl get pod data-transformer -n origin -o jsonpath='{.spec.volumes[?(@.name=="shared-data")].emptyDir}')
+		if [[ -n "$vol" ]]; then
+			score=$((score + 1))
+			details+="Shared emptyDir volume found. "
+		fi
 
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+		local vol_mounts=$(kubectl get pod data-transformer -n origin -o jsonpath='{.spec.containers[*].volumeMounts[?(@.name=="shared-data")].mountPath}')
+		if [[ "$vol_mounts" == *"/var/log"*"/var/log"* ]]; then
+			score=$((score + 2))
+			details+="Volume mounted in both containers. "
+		fi
+	else
+		details+="Pod data-transformer not found. "
+	fi
+
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 # Q3: 5 points
 score_q3() {
-  local score=0
-  local max_points=5
-  local details=""
+	local score=0
+	local max_points=5
+	local details=""
 
-  if resource_exists job index-processor primal; then
-    score=$((score + 2))
-    
-    local mode=$(kubectl get job index-processor -n primal -o jsonpath='{.spec.completionMode}')
-    if [[ "$mode" == "Indexed" ]]; then
-      score=$((score + 1))
-      details+="Indexed completion mode set. "
-    fi
+	if resource_exists job index-processor primal; then
+		score=$((score + 2))
 
-    local completions=$(kubectl get job index-processor -n primal -o jsonpath='{.spec.completions}')
-    if [[ "$completions" == "5" ]]; then
-      score=$((score + 1))
-    fi
-    
-    local para=$(kubectl get job index-processor -n primal -o jsonpath='{.spec.parallelism}')
-    if [[ "$para" == "2" ]]; then
-      score=$((score + 1))
-    fi
-  else
-    details+="Job index-processor not found. "
-  fi
+		local mode=$(kubectl get job index-processor -n primal -o jsonpath='{.spec.completionMode}')
+		if [[ "$mode" == "Indexed" ]]; then
+			score=$((score + 1))
+			details+="Indexed completion mode set. "
+		fi
 
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+		local completions=$(kubectl get job index-processor -n primal -o jsonpath='{.spec.completions}')
+		if [[ "$completions" == "5" ]]; then
+			score=$((score + 1))
+		fi
+
+		local para=$(kubectl get job index-processor -n primal -o jsonpath='{.spec.parallelism}')
+		if [[ "$para" == "2" ]]; then
+			score=$((score + 1))
+		fi
+	else
+		details+="Job index-processor not found. "
+	fi
+
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 # Q4: 6 points
 score_q4() {
-  local score=0
-  local max_points=6
-  local details=""
+	local score=0
+	local max_points=6
+	local details=""
 
-  if resource_exists pod graceful-shutdown ancient; then
-    score=$((score + 2))
-    
-    local grace=$(kubectl get pod graceful-shutdown -n ancient -o jsonpath='{.spec.terminationGracePeriodSeconds}')
-    if [[ "$grace" == "45" ]]; then
-      score=$((score + 2))
-      details+="terminationGracePeriodSeconds is 45. "
-    fi
+	if resource_exists pod graceful-shutdown ancient; then
+		score=$((score + 2))
 
-    local prestop=$(kubectl get pod graceful-shutdown -n ancient -o jsonpath='{.spec.containers[0].lifecycle.preStop.exec.command}')
-    if [[ -n "$prestop" ]]; then
-      score=$((score + 2))
-      details+="preStop hook found. "
-    fi
-  else
-    details+="Pod graceful-shutdown not found. "
-  fi
+		local grace=$(kubectl get pod graceful-shutdown -n ancient -o jsonpath='{.spec.terminationGracePeriodSeconds}')
+		if [[ "$grace" == "45" ]]; then
+			score=$((score + 2))
+			details+="terminationGracePeriodSeconds is 45. "
+		fi
 
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+		local prestop=$(kubectl get pod graceful-shutdown -n ancient -o jsonpath='{.spec.containers[0].lifecycle.preStop.exec.command}')
+		if [[ -n "$prestop" ]]; then
+			score=$((score + 2))
+			details+="preStop hook found. "
+		fi
+	else
+		details+="Pod graceful-shutdown not found. "
+	fi
+
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 # Q5: 6 points
 score_q5() {
-  local score=0
-  local max_points=6
-  local details=""
+	local score=0
+	local max_points=6
+	local details=""
 
-  if helm status genesis-web -n nexus >/dev/null 2>&1; then
-    local reps=$(helm get values genesis-web -n nexus -a | grep -A 0 'replicaCount:' | awk '{print $2}')
-    if [[ "$reps" == "3" ]]; then
-      score=$((score + 3))
-      details+="replicaCount updated. "
-    fi
+	if helm status genesis-web -n nexus >/dev/null 2>&1; then
+		local reps=$(helm get values genesis-web -n nexus -a | grep -A 0 'replicaCount:' | awk '{print $2}')
+		if [[ "$reps" == "3" ]]; then
+			score=$((score + 3))
+			details+="replicaCount updated. "
+		fi
 
-    local label=$(helm get values genesis-web -n nexus -a | grep -A 0 'customLabel:' | awk '{print $2}')
-    if [[ "$label" == "initial-install" ]]; then
-      score=$((score + 3))
-      details+="customLabel retained. "
-    else
-      details+="customLabel lost. "
-    fi
-  else
-    details+="Helm release genesis-web not found. "
-  fi
+		local label=$(helm get values genesis-web -n nexus -a | grep -A 0 'customLabel:' | awk '{print $2}')
+		if [[ "$label" == "initial-install" ]]; then
+			score=$((score + 3))
+			details+="customLabel retained. "
+		else
+			details+="customLabel lost. "
+		fi
+	else
+		details+="Helm release genesis-web not found. "
+	fi
 
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 # Q6: 6 points
 score_q6() {
-  local score=0
-  local max_points=6
-  local details=""
+	local score=0
+	local max_points=6
+	local details=""
 
-  if resource_exists deployment terra-web terra; then
-    score=$((score + 2))
-    
-    local reps=$(kubectl get deployment terra-web -n terra -o jsonpath='{.spec.replicas}')
-    if [[ "$reps" == "4" ]]; then
-      score=$((score + 1))
-    fi
-  else
-    details+="Deployment terra-web not found. "
-  fi
+	if resource_exists deployment terra-web terra; then
+		score=$((score + 2))
 
-  if resource_exists pdb terra-pdb terra; then
-    score=$((score + 1))
-    
-    local min=$(kubectl get pdb terra-pdb -n terra -o jsonpath='{.spec.minAvailable}')
-    if [[ "$min" == "75%" ]]; then
-      score=$((score + 2))
-      details+="PDB minAvailable is 75%. "
-    fi
-  else
-    details+="PDB terra-pdb not found. "
-  fi
+		local reps=$(kubectl get deployment terra-web -n terra -o jsonpath='{.spec.replicas}')
+		if [[ "$reps" == "4" ]]; then
+			score=$((score + 1))
+		fi
+	else
+		details+="Deployment terra-web not found. "
+	fi
 
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+	if resource_exists pdb terra-pdb terra; then
+		score=$((score + 1))
+
+		local min=$(kubectl get pdb terra-pdb -n terra -o jsonpath='{.spec.minAvailable}')
+		if [[ "$min" == "75%" ]]; then
+			score=$((score + 2))
+			details+="PDB minAvailable is 75%. "
+		fi
+	else
+		details+="PDB terra-pdb not found. "
+	fi
+
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 # Q7: 6 points
 score_q7() {
-  local score=0
-  local max_points=6
-  local details=""
+	local score=0
+	local max_points=6
+	local details=""
 
-  if resource_exists deployment eden-api eden; then
-    local img=$(kubectl get deployment eden-api -n eden -o jsonpath='{.spec.template.spec.containers[0].image}')
-    if [[ "$img" == "nginx:1.21" ]]; then
-      score=$((score + 2))
-      details+="Image updated. "
-    fi
+	if resource_exists deployment eden-api eden; then
+		local img=$(kubectl get deployment eden-api -n eden -o jsonpath='{.spec.template.spec.containers[0].image}')
+		if [[ "$img" == "nginx:1.21" ]]; then
+			score=$((score + 2))
+			details+="Image updated. "
+		fi
 
-    local anno=$(kubectl get deployment eden-api -n eden -o jsonpath='{.metadata.annotations.kubernetes\.io/change-cause}')
-    if [[ -n "$anno" ]]; then
-      score=$((score + 2))
-      details+="Revision annotation exists. "
-    fi
+		local anno=$(kubectl get deployment eden-api -n eden -o jsonpath='{.metadata.annotations.kubernetes\.io/change-cause}')
+		if [[ -n "$anno" ]]; then
+			score=$((score + 2))
+			details+="Revision annotation exists. "
+		fi
 
-    local max_s=$(kubectl get deployment eden-api -n eden -o jsonpath='{.spec.strategy.rollingUpdate.maxSurge}')
-    local max_u=$(kubectl get deployment eden-api -n eden -o jsonpath='{.spec.strategy.rollingUpdate.maxUnavailable}')
-    if [[ "$max_s" == "2" || "$max_s" == "25%" ]] && [[ "$max_u" == "0" || "$max_u" == "0%" ]]; then
-      score=$((score + 2))
-      details+="Strategy updated. "
-    fi
-  else
-    details+="Deployment eden-api not found. "
-  fi
+		local max_s=$(kubectl get deployment eden-api -n eden -o jsonpath='{.spec.strategy.rollingUpdate.maxSurge}')
+		local max_u=$(kubectl get deployment eden-api -n eden -o jsonpath='{.spec.strategy.rollingUpdate.maxUnavailable}')
+		if [[ "$max_s" == "2" || "$max_s" == "25%" ]] && [[ "$max_u" == "0" || "$max_u" == "0%" ]]; then
+			score=$((score + 2))
+			details+="Strategy updated. "
+		fi
+	else
+		details+="Deployment eden-api not found. "
+	fi
 
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 # Q8: 6 points
 score_q8() {
-  local score=0
-  local max_points=6
-  local details=""
+	local score=0
+	local max_points=6
+	local details=""
 
-  if resource_exists secret matrix-secret matrix; then
-    score=$((score + 3))
-    
-    local val=$(kubectl get secret matrix-secret -n matrix -o jsonpath='{.data.db-password}' | base64 -d)
-    if [[ "$val" == "supersecret" ]]; then
-      score=$((score + 3))
-      details+="Secret has correct data without hash. "
-    fi
-  else
-    details+="Secret matrix-secret not found (ensure disableNameSuffixHash is used). "
-  fi
+	if resource_exists secret matrix-secret matrix; then
+		score=$((score + 3))
 
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+		local val=$(kubectl get secret matrix-secret -n matrix -o jsonpath='{.data.db-password}' | base64 -d)
+		if [[ "$val" == "supersecret" ]]; then
+			score=$((score + 3))
+			details+="Secret has correct data without hash. "
+		fi
+	else
+		details+="Secret matrix-secret not found (ensure disableNameSuffixHash is used). "
+	fi
+
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 # Q9: 6 points
 score_q9() {
-  local score=0
-  local max_points=6
-  local details=""
+	local score=0
+	local max_points=6
+	local details=""
 
-  if resource_exists pod stuck-pod cosmos; then
-    local phase=$(kubectl get pod stuck-pod -n cosmos -o jsonpath='{.status.phase}')
-    if [[ "$phase" == "Running" ]]; then
-      score=$((score + 6))
-      details+="Pod is running successfully. "
-    else
-      details+="Pod is not Running. "
-    fi
-  else
-    details+="Pod stuck-pod not found. "
-  fi
+	if resource_exists pod stuck-pod cosmos; then
+		local phase=$(kubectl get pod stuck-pod -n cosmos -o jsonpath='{.status.phase}')
+		if [[ "$phase" == "Running" ]]; then
+			score=$((score + 6))
+			details+="Pod is running successfully. "
+		else
+			details+="Pod is not Running. "
+		fi
+	else
+		details+="Pod stuck-pod not found. "
+	fi
 
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 # Q10: 5 points
 score_q10() {
-  local score=0
-  local max_points=5
-  local details=""
-  local file_path="./exam/course/10/events.txt"
-  
-  if [ -f "$file_path" ]; then
-    score=$((score + 2))
-    
-    local header=$(head -n 1 "$file_path")
-    if echo "$header" | grep -q "TYPE.*REASON.*MESSAGE"; then
-      score=$((score + 3))
-      details+="File created with correct headers. "
-    else
-      details+="File headers incorrect. "
-    fi
-  else
-    details+="File not found. "
-  fi
+	local score=0
+	local max_points=5
+	local details=""
+	local file_path="./exam/course/10/events.txt"
 
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+	if [ -f "$file_path" ]; then
+		score=$((score + 2))
+
+		local header=$(head -n 1 "$file_path")
+		if echo "$header" | grep -q "TYPE.*REASON.*MESSAGE"; then
+			score=$((score + 3))
+			details+="File created with correct headers. "
+		else
+			details+="File headers incorrect. "
+		fi
+	else
+		details+="File not found. "
+	fi
+
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 # Q11: 6 points
 score_q11() {
-  local score=0
-  local max_points=6
-  local details=""
-  local script_path="./exam/course/11/check.sh"
-  
-  if [ -f "$script_path" ]; then
-    score=$((score + 2))
-    
-    if grep -q "kubectl port-forward.*svc/backend-api.*9999:8080" "$script_path"; then
-      score=$((score + 2))
-    fi
-    
-    if grep -q "curl.*http://localhost:9999/health" "$script_path"; then
-      score=$((score + 2))
-      details+="Port-forward script appears correct. "
-    fi
-  else
-    details+="Script check.sh not found. "
-  fi
+	local score=0
+	local max_points=6
+	local details=""
+	local script_path="./exam/course/11/check.sh"
 
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+	if [ -f "$script_path" ]; then
+		score=$((score + 2))
+
+		if grep -q "kubectl port-forward.*svc/backend-api.*9999:8080" "$script_path"; then
+			score=$((score + 2))
+		fi
+
+		if grep -q "curl.*http://localhost:9999/health" "$script_path"; then
+			score=$((score + 2))
+			details+="Port-forward script appears correct. "
+		fi
+	else
+		details+="Script check.sh not found. "
+	fi
+
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 # Q12: 7 points
 score_q12() {
-  local score=0
-  local max_points=7
-  local details=""
+	local score=0
+	local max_points=7
+	local details=""
 
-  if resource_exists pod projected-pod origin; then
-    score=$((score + 1))
-    
-    local proj=$(kubectl get pod projected-pod -n origin -o jsonpath='{.spec.volumes[?(@.projected)].projected.sources}')
-    if [[ -n "$proj" ]]; then
-      if echo "$proj" | grep -q "my-secret"; then score=$((score + 1)); fi
-      if echo "$proj" | grep -q "my-config"; then score=$((score + 1)); fi
-      if echo "$proj" | grep -q "downwardAPI"; then score=$((score + 2)); fi
-      if echo "$proj" | grep -q "serviceAccountToken"; then score=$((score + 2)); fi
-      details+="Projected volume sources checked. "
-    else
-      details+="Projected volume not found. "
-    fi
-  else
-    details+="Pod projected-pod not found. "
-  fi
+	if resource_exists pod projected-pod origin; then
+		score=$((score + 1))
 
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+		local proj=$(kubectl get pod projected-pod -n origin -o jsonpath='{.spec.volumes[?(@.projected)].projected.sources}')
+		if [[ -n "$proj" ]]; then
+			if echo "$proj" | grep -q "my-secret"; then score=$((score + 1)); fi
+			if echo "$proj" | grep -q "my-config"; then score=$((score + 1)); fi
+			if echo "$proj" | grep -q "downwardAPI"; then score=$((score + 2)); fi
+			if echo "$proj" | grep -q "serviceAccountToken"; then score=$((score + 2)); fi
+			details+="Projected volume sources checked. "
+		else
+			details+="Projected volume not found. "
+		fi
+	else
+		details+="Pod projected-pod not found. "
+	fi
+
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 # Q13: 5 points
 score_q13() {
-  local score=0
-  local max_points=5
-  local details=""
+	local score=0
+	local max_points=5
+	local details=""
 
-  if resource_exists secret static-creds primal; then
-    score=$((score + 2))
-    
-    local im=$(kubectl get secret static-creds -n primal -o jsonpath='{.immutable}')
-    if [[ "$im" == "true" ]]; then
-      score=$((score + 3))
-      details+="Secret is immutable. "
-    else
-      details+="Secret is not immutable. "
-    fi
-  else
-    details+="Secret static-creds not found. "
-  fi
+	if resource_exists secret static-creds primal; then
+		score=$((score + 2))
 
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+		local im=$(kubectl get secret static-creds -n primal -o jsonpath='{.immutable}')
+		if [[ "$im" == "true" ]]; then
+			score=$((score + 3))
+			details+="Secret is immutable. "
+		else
+			details+="Secret is not immutable. "
+		fi
+	else
+		details+="Secret static-creds not found. "
+	fi
+
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 # Q14: 7 points
 score_q14() {
-  local score=0
-  local max_points=7
-  local details=""
+	local score=0
+	local max_points=7
+	local details=""
 
-  if resource_exists pod secure-pod ancient; then
-    score=$((score + 1))
-    
-    local sc=$(kubectl get pod secure-pod -n ancient -o jsonpath='{.spec.containers[0].securityContext}')
-    
-    if echo "$sc" | grep -q '"runAsNonRoot":true'; then score=$((score + 1)); fi
-    if echo "$sc" | grep -q '"readOnlyRootFilesystem":true'; then score=$((score + 2)); fi
-    if echo "$sc" | grep -q '"allowPrivilegeEscalation":false'; then score=$((score + 1)); fi
-    
-    local drop=$(kubectl get pod secure-pod -n ancient -o jsonpath='{.spec.containers[0].securityContext.capabilities.drop}')
-    if [[ "$drop" == *"ALL"* ]]; then score=$((score + 2)); fi
-    
-    details+="SecurityContext checked. "
-  else
-    details+="Pod secure-pod not found. "
-  fi
+	if resource_exists pod secure-pod ancient; then
+		score=$((score + 1))
 
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+		local sc=$(kubectl get pod secure-pod -n ancient -o jsonpath='{.spec.containers[0].securityContext}')
+
+		if echo "$sc" | grep -q '"runAsNonRoot":true'; then score=$((score + 1)); fi
+		if echo "$sc" | grep -q '"readOnlyRootFilesystem":true'; then score=$((score + 2)); fi
+		if echo "$sc" | grep -q '"allowPrivilegeEscalation":false'; then score=$((score + 1)); fi
+
+		local drop=$(kubectl get pod secure-pod -n ancient -o jsonpath='{.spec.containers[0].securityContext.capabilities.drop}')
+		if [[ "$drop" == *"ALL"* ]]; then score=$((score + 2)); fi
+
+		details+="SecurityContext checked. "
+	else
+		details+="Pod secure-pod not found. "
+	fi
+
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 # Q15: 6 points
 score_q15() {
-  local score=0
-  local max_points=6
-  local details=""
+	local score=0
+	local max_points=6
+	local details=""
 
-  if resource_exists clusterrole monitor-viewer; then
-    score=$((score + 2))
-    
-    local lbl=$(kubectl get clusterrole monitor-viewer -o jsonpath='{.metadata.labels}')
-    if [[ -n "$lbl" ]]; then
-      score=$((score + 2))
-      details+="monitor-viewer has labels. "
-    fi
-  else
-    details+="ClusterRole monitor-viewer not found. "
-  fi
+	if resource_exists clusterrole monitor-viewer; then
+		score=$((score + 2))
 
-  if resource_exists clusterrole aggregated-monitor; then
-    local agg=$(kubectl get clusterrole aggregated-monitor -o jsonpath='{.aggregationRule}')
-    if [[ -n "$agg" ]]; then
-      score=$((score + 2))
-      details+="aggregated-monitor has aggregationRule. "
-    fi
-  else
-    details+="ClusterRole aggregated-monitor not found. "
-  fi
+		local lbl=$(kubectl get clusterrole monitor-viewer -o jsonpath='{.metadata.labels}')
+		if [[ -n "$lbl" ]]; then
+			score=$((score + 2))
+			details+="monitor-viewer has labels. "
+		fi
+	else
+		details+="ClusterRole monitor-viewer not found. "
+	fi
 
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+	if resource_exists clusterrole aggregated-monitor; then
+		local agg=$(kubectl get clusterrole aggregated-monitor -o jsonpath='{.aggregationRule}')
+		if [[ -n "$agg" ]]; then
+			score=$((score + 2))
+			details+="aggregated-monitor has aggregationRule. "
+		fi
+	else
+		details+="ClusterRole aggregated-monitor not found. "
+	fi
+
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 # Q16: 6 points
 score_q16() {
-  local score=0
-  local max_points=6
-  local details=""
+	local score=0
+	local max_points=6
+	local details=""
 
-  if resource_exists resourcequota priority-quota eden; then
-    score=$((score + 2))
-    
-    local pods=$(kubectl get resourcequota priority-quota -n eden -o jsonpath='{.spec.hard.pods}')
-    if [[ "$pods" == "5" ]]; then score=$((score + 1)); fi
-    
-    local cpu=$(kubectl get resourcequota priority-quota -n eden -o jsonpath='{.spec.hard.requests\.cpu}')
-    if [[ "$cpu" == "2" ]]; then score=$((score + 1)); fi
-    
-    local scopes=$(kubectl get resourcequota priority-quota -n eden -o jsonpath='{.spec.scopeSelector.matchExpressions[0].scopeName}')
-    if [[ "$scopes" == "PriorityClass" ]]; then 
-      score=$((score + 2))
-      details+="Scope correctly defined. "
-    fi
-  else
-    details+="ResourceQuota priority-quota not found. "
-  fi
+	if resource_exists resourcequota priority-quota eden; then
+		score=$((score + 2))
 
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+		local pods=$(kubectl get resourcequota priority-quota -n eden -o jsonpath='{.spec.hard.pods}')
+		if [[ "$pods" == "5" ]]; then score=$((score + 1)); fi
+
+		local cpu=$(kubectl get resourcequota priority-quota -n eden -o jsonpath='{.spec.hard.requests\.cpu}')
+		if [[ "$cpu" == "2" ]]; then score=$((score + 1)); fi
+
+		local scopes=$(kubectl get resourcequota priority-quota -n eden -o jsonpath='{.spec.scopeSelector.matchExpressions[0].scopeName}')
+		if [[ "$scopes" == "PriorityClass" ]]; then
+			score=$((score + 2))
+			details+="Scope correctly defined. "
+		fi
+	else
+		details+="ResourceQuota priority-quota not found. "
+	fi
+
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 # Q17: 6 points
 score_q17() {
-  local score=0
-  local max_points=6
-  local details=""
+	local score=0
+	local max_points=6
+	local details=""
 
-  if resource_exists networkpolicy allow-named-port matrix; then
-    score=$((score + 2))
-    
-    local port=$(kubectl get networkpolicy allow-named-port -n matrix -o jsonpath='{.spec.ingress[0].ports[0].port}')
-    if [[ "$port" == "api-port" ]]; then
-      score=$((score + 4))
-      details+="Named port used correctly. "
-    fi
-  else
-    details+="NetworkPolicy allow-named-port not found. "
-  fi
+	if resource_exists networkpolicy allow-named-port matrix; then
+		score=$((score + 2))
 
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+		local port=$(kubectl get networkpolicy allow-named-port -n matrix -o jsonpath='{.spec.ingress[0].ports[0].port}')
+		if [[ "$port" == "api-port" ]]; then
+			score=$((score + 4))
+			details+="Named port used correctly. "
+		fi
+	else
+		details+="NetworkPolicy allow-named-port not found. "
+	fi
+
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 # Q18: 5 points
 score_q18() {
-  local score=0
-  local max_points=5
-  local details=""
+	local score=0
+	local max_points=5
+	local details=""
 
-  if resource_exists ingress cosmos-ingress cosmos; then
-    score=$((score + 1))
-    
-    local ic=$(kubectl get ingress cosmos-ingress -n cosmos -o jsonpath='{.spec.ingressClassName}')
-    if [[ "$ic" == "nginx" ]]; then
-      score=$((score + 2))
-      details+="ingressClassName is nginx. "
-    fi
+	if resource_exists ingress cosmos-ingress cosmos; then
+		score=$((score + 1))
 
-    local port=$(kubectl get ingress cosmos-ingress -n cosmos -o jsonpath='{.spec.rules[0].http.paths[0].backend.service.port.number}')
-    if [[ "$port" == "80" ]]; then
-      score=$((score + 2))
-      details+="Port corrected to 80. "
-    fi
-  else
-    details+="Ingress cosmos-ingress not found. "
-  fi
+		local ic=$(kubectl get ingress cosmos-ingress -n cosmos -o jsonpath='{.spec.ingressClassName}')
+		if [[ "$ic" == "nginx" ]]; then
+			score=$((score + 2))
+			details+="ingressClassName is nginx. "
+		fi
 
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+		local port=$(kubectl get ingress cosmos-ingress -n cosmos -o jsonpath='{.spec.rules[0].http.paths[0].backend.service.port.number}')
+		if [[ "$port" == "80" ]]; then
+			score=$((score + 2))
+			details+="Port corrected to 80. "
+		fi
+	else
+		details+="Ingress cosmos-ingress not found. "
+	fi
+
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 # Q19: 6 points
 score_q19() {
-  local score=0
-  local max_points=6
-  local details=""
-  local fqdn_file="./exam/course/19/fqdn.txt"
+	local score=0
+	local max_points=6
+	local details=""
+	local fqdn_file="./exam/course/19/fqdn.txt"
 
-  if resource_exists pod dns-tester zenith; then
-    score=$((score + 2))
-  fi
+	if resource_exists pod dns-tester zenith; then
+		score=$((score + 2))
+	fi
 
-  if [ -f "$fqdn_file" ]; then
-    local content=$(cat "$fqdn_file")
-    if [[ "$content" == *"data-svc.ancient.svc.cluster.local"* ]]; then
-      score=$((score + 4))
-      details+="FQDN correct. "
-    else
-      details+="FQDN incorrect in file. "
-    fi
-  else
-    details+="File fqdn.txt not found. "
-  fi
+	if [ -f "$fqdn_file" ]; then
+		local content=$(cat "$fqdn_file")
+		if [[ "$content" == *"data-svc.ancient.svc.cluster.local"* ]]; then
+			score=$((score + 4))
+			details+="FQDN correct. "
+		else
+			details+="FQDN incorrect in file. "
+		fi
+	else
+		details+="File fqdn.txt not found. "
+	fi
 
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 # Q20: 6 points
 score_q20() {
-  local score=0
-  local max_points=6
-  local details=""
+	local score=0
+	local max_points=6
+	local details=""
 
-  if resource_exists networkpolicy isolate-namespace nexus; then
-    score=$((score + 2))
-    
-    local types=$(kubectl get networkpolicy isolate-namespace -n nexus -o jsonpath='{.spec.policyTypes}')
-    if [[ "$types" == *"Ingress"* && "$types" == *"Egress"* ]]; then
-      score=$((score + 2))
-    fi
+	if resource_exists networkpolicy isolate-namespace nexus; then
+		score=$((score + 2))
 
-    local psel=$(kubectl get networkpolicy isolate-namespace -n nexus -o jsonpath='{.spec.podSelector}')
-    if [[ "$psel" == "{}" ]]; then
-      score=$((score + 2))
-      details+="Policy isolates correctly. "
-    fi
-  else
-    details+="NetworkPolicy isolate-namespace not found. "
-  fi
+		local types=$(kubectl get networkpolicy isolate-namespace -n nexus -o jsonpath='{.spec.policyTypes}')
+		if [[ "$types" == *"Ingress"* && "$types" == *"Egress"* ]]; then
+			score=$((score + 2))
+		fi
 
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+		local psel=$(kubectl get networkpolicy isolate-namespace -n nexus -o jsonpath='{.spec.podSelector}')
+		if [[ "$psel" == "{}" ]]; then
+			score=$((score + 2))
+			details+="Policy isolates correctly. "
+		fi
+	else
+		details+="NetworkPolicy isolate-namespace not found. "
+	fi
+
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }

--- a/exams/ckad-simulation18/solutions.md
+++ b/exams/ckad-simulation18/solutions.md
@@ -25,6 +25,7 @@ docker push localhost:5000/genesis-app:v1
 # 4. Create Pod
 kubectl run genesis-pod -n genesis --image=localhost:5000/genesis-app:v1
 ```
+
 **Explanation:** The `USER` instruction sets the user for the container. Building, tagging, and pushing standard docker commands.
 
 ---
@@ -57,6 +58,7 @@ spec:
       mountPath: /var/log
 EOF
 ```
+
 **Explanation:** The adapter pattern uses an `emptyDir` volume shared between containers. The adapter container reads from the shared volume and modifies the data.
 
 ---
@@ -83,6 +85,7 @@ spec:
       restartPolicy: Never
 EOF
 ```
+
 **Explanation:** Indexed jobs provide the `$JOB_COMPLETION_INDEX` environment variable to each pod, allowing them to process specific slices of data.
 
 ---
@@ -107,6 +110,7 @@ spec:
           command: ["sh", "-c", "sleep 10 && nginx -s quit"]
 EOF
 ```
+
 **Explanation:** The `preStop` hook runs before the container receives a SIGTERM. `terminationGracePeriodSeconds` gives it enough time to complete.
 
 ---
@@ -117,6 +121,7 @@ EOF
 # Upgrade the release reusing existing values
 helm upgrade genesis-web ./exam/course/5/genesis-web-chart -n nexus --reuse-values --set replicaCount=3
 ```
+
 **Explanation:** `--reuse-values` keeps all previously set custom values, while `--set` applies the new changes.
 
 ---
@@ -141,6 +146,7 @@ spec:
       app: terra-web
 EOF
 ```
+
 **Explanation:** A PodDisruptionBudget ensures a minimum number of pods remain available during voluntary disruptions.
 
 ---
@@ -157,6 +163,7 @@ kubectl annotate deployment eden-api kubernetes.io/change-cause="Updated to ngin
 # Patch strategy
 kubectl patch deployment eden-api -n eden -p '{"spec":{"strategy":{"type":"RollingUpdate","rollingUpdate":{"maxSurge":2,"maxUnavailable":0}}}}'
 ```
+
 **Explanation:** Using `set image`, `annotate`, and `patch` to modify the deployment without writing a full YAML file.
 
 ---
@@ -177,6 +184,7 @@ EOF
 # Apply Kustomize
 kubectl kustomize ./exam/course/8/kustomize | kubectl apply -n matrix -f -
 ```
+
 **Explanation:** Kustomize `secretGenerator` creates secrets. `disableNameSuffixHash: true` prevents the random hash suffix.
 
 ---
@@ -191,6 +199,7 @@ kubectl get pod stuck-pod -n cosmos -o yaml > stuck.yaml
 sed -i 's/exit 1/exit 0/g' stuck.yaml
 kubectl replace --force -f stuck.yaml
 ```
+
 **Explanation:** The init container was intentionally exiting with 1. We change it to 0 so it succeeds.
 
 ---
@@ -200,6 +209,7 @@ kubectl replace --force -f stuck.yaml
 ```bash
 kubectl get events -n zenith -o custom-columns=TYPE:.type,REASON:.reason,MESSAGE:.message > ./exam/course/10/events.txt
 ```
+
 **Explanation:** `custom-columns` allows exact formatting of kubectl output.
 
 ---
@@ -217,6 +227,7 @@ kill \$PF_PID
 EOF
 chmod +x ./exam/course/11/check.sh
 ```
+
 **Explanation:** Port-forward runs in the background. We fetch the endpoint, log it, then kill the process.
 
 ---
@@ -261,6 +272,7 @@ spec:
           audience: vault
 EOF
 ```
+
 **Explanation:** Projected volumes combine multiple sources (Secrets, ConfigMaps, DownwardAPI, ServiceAccountTokens) into a single directory.
 
 ---
@@ -280,6 +292,7 @@ stringData:
   api-key: 12345ABC
 EOF
 ```
+
 **Explanation:** Setting `immutable: true` on a Secret or ConfigMap prevents any updates to its data.
 
 ---
@@ -317,6 +330,7 @@ spec:
     emptyDir: {}
 EOF
 ```
+
 **Explanation:** Hardening settings require an emptyDir for nginx because it needs to write to `/var/cache/nginx` and `/var/run` when the root FS is read-only.
 
 ---
@@ -347,6 +361,7 @@ aggregationRule:
 rules: []
 EOF
 ```
+
 **Explanation:** Aggregation allows a ClusterRole to dynamically inherit rules from other ClusterRoles based on labels.
 
 ---
@@ -374,6 +389,7 @@ spec:
       - high-priority
 EOF
 ```
+
 **Explanation:** ResourceQuotas can be restricted to specific scopes, like PriorityClasses.
 
 ---
@@ -403,6 +419,7 @@ spec:
       protocol: TCP
 EOF
 ```
+
 **Explanation:** Network Policies support named ports, which allows decoupling the policy from the specific port number.
 
 ---
@@ -433,6 +450,7 @@ spec:
               number: 80
 EOF
 ```
+
 **Explanation:** Explicitly setting `ingressClassName` is the standard way to associate an Ingress with a controller.
 
 ---
@@ -443,6 +461,7 @@ EOF
 kubectl run dns-tester -n zenith --image=busybox:1.32 -- sleep 3600
 echo "data-svc.ancient.svc.cluster.local" > ./exam/course/19/fqdn.txt
 ```
+
 **Explanation:** Cross-namespace service communication requires the FQDN: `<service-name>.<namespace>.svc.cluster.local`.
 
 ---
@@ -468,4 +487,5 @@ spec:
   - {}
 EOF
 ```
+
 **Explanation:** `podSelector: {}` targets all pods in the namespace. `from: - podSelector: {}` allows traffic from all pods in the same namespace. Egress with `{}` allows all outbound.

--- a/exams/ckad-simulation19/post-setup.sh
+++ b/exams/ckad-simulation19/post-setup.sh
@@ -2,35 +2,35 @@
 set -e
 
 exam_post_setup() {
-    echo "Running post-setup for CKAD Simulation 19..."
+	echo "Running post-setup for CKAD Simulation 19..."
 
-    local BASE_DIR="./exam/course/19"
-    
-    # Q1 Setup
-    mkdir -p "$BASE_DIR/q1"
-    cat <<EOF2 > "$BASE_DIR/q1/main.go"
+	local BASE_DIR="./exam/course/19"
+
+	# Q1 Setup
+	mkdir -p "$BASE_DIR/q1"
+	cat <<EOF2 >"$BASE_DIR/q1/main.go"
 package main
 import "fmt"
 func main() {
     fmt.Println("Hello Dojo")
 }
 EOF2
-    cat <<EOF2 > "$BASE_DIR/q1/Dockerfile"
+	cat <<EOF2 >"$BASE_DIR/q1/Dockerfile"
 FROM golang:1.20-alpine
 WORKDIR /app
 COPY . .
 # Add multi-stage steps
 EOF2
 
-    # Q5 Setup (Helm)
-    helm create /tmp/guardian-app > /dev/null 2>&1
-    helm install guardian-app /tmp/guardian-app -n haven --set replicaCount=1 --set image.tag=1.16.0 > /dev/null 2>&1
-    mkdir -p "$BASE_DIR/q5"
-    touch "$BASE_DIR/q5/old-values.yaml" "$BASE_DIR/q5/new-values.yaml" "$BASE_DIR/q5/values.yaml"
+	# Q5 Setup (Helm)
+	helm create /tmp/guardian-app >/dev/null 2>&1
+	helm install guardian-app /tmp/guardian-app -n haven --set replicaCount=1 --set image.tag=1.16.0 >/dev/null 2>&1
+	mkdir -p "$BASE_DIR/q5"
+	touch "$BASE_DIR/q5/old-values.yaml" "$BASE_DIR/q5/new-values.yaml" "$BASE_DIR/q5/values.yaml"
 
-    # Q8 Setup (Kustomize)
-    mkdir -p "$BASE_DIR/q8"
-    cat <<EOF2 > "$BASE_DIR/q8/deployment.yaml"
+	# Q8 Setup (Kustomize)
+	mkdir -p "$BASE_DIR/q8"
+	cat <<EOF2 >"$BASE_DIR/q8/deployment.yaml"
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -50,19 +50,19 @@ spec:
         image: nginx:alpine
 EOF2
 
-    cat <<EOF2 > "$BASE_DIR/q8/kustomization.yaml"
+	cat <<EOF2 >"$BASE_DIR/q8/kustomization.yaml"
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - deployment.yaml
 EOF2
 
-    # Q10 Setup
-    mkdir -p "$BASE_DIR/q10"
+	# Q10 Setup
+	mkdir -p "$BASE_DIR/q10"
 
-    # Q13 Setup
-    mkdir -p "$BASE_DIR/q13"
+	# Q13 Setup
+	mkdir -p "$BASE_DIR/q13"
 
-    echo "Post-setup complete."
-  return 0
+	echo "Post-setup complete."
+	return 0
 }

--- a/exams/ckad-simulation19/questions.md
+++ b/exams/ckad-simulation19/questions.md
@@ -26,9 +26,11 @@
 | **File to create** | `./exam/course/19/q1/Dockerfile` |
 
 ### Task
+
 You have been tasked to optimize a container build process using multi-stage builds.
 In the directory `./exam/course/19/q1/`, there is a basic `main.go` application and an incomplete `Dockerfile`.
 Modify the `Dockerfile` to use a multi-stage build:
+
 1. Stage 1: Name it `builder` and use `golang:1.20-alpine` as the base image. Compile the Go app here.
 2. Stage 2: Use `alpine:3.18` as the base image. Copy the compiled binary from the `builder` stage to `/app/main`.
 3. Create a Pod named `optimized-build` in the `ward` namespace using the `nginx:alpine` image (for testing purposes, as we cannot build and push to registry in this mock easily without a registry pre-configured. Just create the pod definition with the `nginx:alpine` image and save the Dockerfile). Actually, save the Dockerfile locally and let the scoring function check it.
@@ -46,7 +48,9 @@ Modify the `Dockerfile` to use a multi-stage build:
 | **Resources** | Pod |
 
 ### Task
+
 Create a Pod named `logging-pod` in the `aegis` namespace with two containers:
+
 1. Main container: Name `app-container`, Image `busybox:1.36`, command `sh, -c, "while true; do echo 'App running' >> /var/log/app.log; sleep 5; done"`.
 2. Sidecar container: Name `log-tailer`, Image `busybox:1.36`, command `sh, -c, "tail -f /var/log/app.log"`.
 3. Both containers must mount an `emptyDir` volume at `/var/log`.
@@ -65,7 +69,9 @@ Create a Pod named `logging-pod` in the `aegis` namespace with two containers:
 | **Resources** | CronJob, Job |
 
 ### Task
+
 A CronJob named `backup-cj` exists in the `shield` namespace. It runs every 10 minutes.
+
 1. Suspend the existing CronJob `backup-cj`.
 2. Manually trigger a Job named `manual-backup` from this CronJob immediately.
 
@@ -82,7 +88,9 @@ A CronJob named `backup-cj` exists in the `shield` namespace. It runs every 10 m
 | **Resources** | Pod |
 
 ### Task
+
 Create a Pod named `init-chain` in the `guardian` namespace that utilizes a sequence of initialization steps.
+
 1. The Pod should have an `emptyDir` volume named `shared-data` mounted at `/data` in all containers.
 2. It should have 3 init containers running sequentially:
    - Init 1: `busybox` image, writes `step1` to `/data/1.txt`.
@@ -104,7 +112,9 @@ Create a Pod named `init-chain` in the `guardian` namespace that utilizes a sequ
 | **File to create** | `./exam/course/19/q5/values.yaml` |
 
 ### Task
+
 A Helm release named `guardian-app` is deployed in the `haven` namespace.
+
 1. Download its current values to `./exam/course/19/q5/old-values.yaml`.
 2. Update the replica count to 3 and the image tag to `latest` in a new file `./exam/course/19/q5/new-values.yaml`.
 3. Upgrade the release using `./exam/course/19/q5/new-values.yaml` without changing other existing configurations.
@@ -122,8 +132,10 @@ A Helm release named `guardian-app` is deployed in the `haven` namespace.
 | **Resources** | Deployment, HPA |
 
 ### Task
+
 In the `refuge` namespace, there is a Deployment named `api-server` managed by an HPA named `api-hpa`.
 There is a conflict causing issues. The Deployment specifies 5 replicas, while the HPA specifies a minimum of 2 and maximum of 10.
+
 1. Remove the static replica count from the Deployment specification.
 2. Ensure the HPA targets the Deployment correctly and has CPU utilization target set to 75%.
 3. Scale the Deployment manually to 3 replicas (which the HPA might later override, but just perform the scale action if possible, or ensure it rests at min replicas). Actually, just fix the HPA to target 75% CPU and min 2 max 10.
@@ -141,7 +153,9 @@ There is a conflict causing issues. The Deployment specifies 5 replicas, while t
 | **Resources** | Deployment |
 
 ### Task
+
 Perform a complex rollout for a Deployment named `worker-deploy` in the `bastion` namespace.
+
 1. The Deployment currently uses `nginx:1.24.0` and `redis:6.2`.
 2. Update the `nginx` container to use `nginx:1.25.0`.
 3. Update the `redis` container to use `redis:7.0`.
@@ -162,7 +176,9 @@ Perform a complex rollout for a Deployment named `worker-deploy` in the `bastion
 | **File to create** | `./exam/course/19/q8/` |
 
 ### Task
+
 Using Kustomize in `./exam/course/19/q8/`:
+
 1. Create a `kustomization.yaml` that includes `deployment.yaml` as a resource.
 2. Apply a patch `patch.yaml` to change the replicas of the deployment to `4`.
 3. Build the Kustomization and apply it to the `bulwark` namespace.
@@ -180,7 +196,9 @@ Using Kustomize in `./exam/course/19/q8/`:
 | **Resources** | Deployment, Secret |
 
 ### Task
+
 A Deployment named `broken-app` in the `anchor` namespace is failing to start. Troubleshoot and fix the issues:
+
 1. The image name is misspelled. Change it from `ngnx:latest` to `nginx:1.25.0`.
 2. A required Secret named `app-secret` is missing. Create it with key `PASSWORD` and value `securepass`.
 3. The container port is incorrectly set to `8080`. Fix it to `80`.
@@ -199,6 +217,7 @@ A Deployment named `broken-app` in the `anchor` namespace is failing to start. T
 | **File to create** | `./exam/course/19/q10/cpu-usage.txt` |
 
 ### Task
+
 Find the Pod in the `helm` namespace with the label `tier=backend` that is consuming the most CPU.
 Write the name of this Pod to `./exam/course/19/q10/cpu-usage.txt`.
 
@@ -217,7 +236,9 @@ Write the name of this Pod to `./exam/course/19/q10/cpu-usage.txt`.
 | **Resources** | Pod |
 
 ### Task
+
 Create a Pod named `monitored-pod` in the `ward` namespace using `nginx:alpine` image with comprehensive monitoring.
+
 1. Startup Probe: HTTP GET `/` on port 80, initial delay 5s, failure threshold 10, period 5s.
 2. Readiness Probe: HTTP GET `/` on port 80, initial delay 5s, period 10s.
 3. Liveness Probe: TCP Socket on port 80, initial delay 15s, period 20s.
@@ -235,13 +256,16 @@ Create a Pod named `monitored-pod` in the `ward` namespace using `nginx:alpine` 
 | **Resources** | ConfigMap, Pod |
 
 ### Task
+
 1. Create a ConfigMap named `app-config` in `aegis` namespace with multiline data under key `config.json`:
+
 ```json
 {
   "mode": "production",
   "timeout": 30
 }
 ```
+
 2. Create a Pod named `config-pod` in `aegis` namespace (`nginx:alpine`) that mounts this ConfigMap at `/etc/app/config.json` via a volume.
 
 ---
@@ -258,6 +282,7 @@ Create a Pod named `monitored-pod` in the `ward` namespace using `nginx:alpine` 
 | **File to create** | `./exam/course/19/q13/token.txt` |
 
 ### Task
+
 1. Create a ServiceAccount named `vault-sa` in the `shield` namespace.
 2. Generate a token for this ServiceAccount using the TokenRequest API (via `kubectl create token`) with an expiration of 24 hours.
 3. Save the token to `./exam/course/19/q13/token.txt`.
@@ -275,8 +300,10 @@ Create a Pod named `monitored-pod` in the `ward` namespace using `nginx:alpine` 
 | **Resources** | Pod |
 
 ### Task
+
 Create a Pod named `secure-pod` in the `guardian` namespace with `nginx:alpine`.
 Configure the SecurityContext:
+
 1. At the Pod level: `runAsUser: 1000`, `runAsGroup: 3000`.
 2. At the Container level: `runAsUser: 2000`, `allowPrivilegeEscalation: false`, and drop `ALL` capabilities.
 
@@ -293,7 +320,9 @@ Configure the SecurityContext:
 | **Resources** | Role, RoleBinding |
 
 ### Task
+
 Create RBAC resources in the `haven` namespace:
+
 1. A Role named `config-editor` that allows `get`, `update`, and `patch` operations, but strictly only on ConfigMaps named `primary-config` and `secondary-config`.
 2. A RoleBinding named `dev-config-binding` that binds this Role to a user named `dev-user`.
 
@@ -310,7 +339,9 @@ Create RBAC resources in the `haven` namespace:
 | **Resources** | Namespace |
 
 ### Task
+
 Configure PodSecurityAdmission for the `refuge` namespace.
+
 1. Apply the `restricted` profile for `enforce` mode.
 2. Apply the `baseline` profile for `warn` mode.
 
@@ -327,7 +358,9 @@ Configure PodSecurityAdmission for the `refuge` namespace.
 | **Resources** | NetworkPolicy |
 
 ### Task
+
 Create a NetworkPolicy named `db-protect` in the `bastion` namespace.
+
 1. It should target pods with `app=db`.
 2. Allow INGRESS on port `5432` only from pods with `app=backend` in the same namespace.
 3. Allow EGRESS to a specific IP range `10.0.0.0/24` on port `443` only.
@@ -346,7 +379,9 @@ Create a NetworkPolicy named `db-protect` in the `bastion` namespace.
 | **Resources** | Ingress |
 
 ### Task
+
 Create an Ingress named `regex-ingress` in the `bulwark` namespace.
+
 1. Assume an IngressClass named `nginx` exists. Use it.
 2. Route traffic for host `api.dojo.com` with path `/v1/.*` (regex match) to a Service named `v1-service` on port `80`.
 3. Route path `/v2/.*` to a Service named `v2-service` on port `80`.
@@ -365,7 +400,9 @@ Create an Ingress named `regex-ingress` in the `bulwark` namespace.
 | **Resources** | Service |
 
 ### Task
+
 Create a Service named `topology-service` in the `anchor` namespace.
+
 1. Target pods with label `app=geo`.
 2. Port `80`, targetPort `80`.
 3. Enable Topology Aware Routing (Topology Aware Hints) by adding the appropriate annotation `service.kubernetes.io/topology-mode: Auto` (or `Auto` on `service.kubernetes.io/topology-aware-hints`).
@@ -383,6 +420,7 @@ Create a Service named `topology-service` in the `anchor` namespace.
 | **Resources** | NetworkPolicy |
 
 ### Task
+
 Create a NetworkPolicy named `strict-net` in the `helm` namespace.
 Target pods with label `role=frontend`.
 Deny all INGRESS and EGRESS traffic for these pods (default deny).

--- a/exams/ckad-simulation19/scoring-functions.sh
+++ b/exams/ckad-simulation19/scoring-functions.sh
@@ -2,501 +2,504 @@
 # CKAD Simulation 19 - Scoring Functions
 # Total Points: 120
 
-SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 source "$SCRIPT_DIR/../../scripts/lib/common.sh" 2>/dev/null || true
 
 EXAM_DIR="./exam/course/19"
 
 score_q1() {
-  local score=0
-  local max_points=6
-  local details=""
+	local score=0
+	local max_points=6
+	local details=""
 
-  if [ -f "$EXAM_DIR/q1/Dockerfile" ]; from_cnt=$(grep -ci "FROM" "$EXAM_DIR/q1/Dockerfile"); then
-    if [ "$from_cnt" -ge 2 ]; then
-      score=$((score + 3))
-      details="Multi-stage Dockerfile present (3/3). "
-    else
-      details="Dockerfile not multi-stage (0/3). "
-    fi
-  else
-    details="Dockerfile not found (0/3). "
-  fi
+	if
+		[ -f "$EXAM_DIR/q1/Dockerfile" ]
+		from_cnt=$(grep -ci "FROM" "$EXAM_DIR/q1/Dockerfile")
+	then
+		if [ "$from_cnt" -ge 2 ]; then
+			score=$((score + 3))
+			details="Multi-stage Dockerfile present (3/3). "
+		else
+			details="Dockerfile not multi-stage (0/3). "
+		fi
+	else
+		details="Dockerfile not found (0/3). "
+	fi
 
-  if resource_exists "pod" "optimized-build" "ward"; then
-    score=$((score + 3))
-    details+="Pod optimized-build found (3/3)."
-  else
-    details+="Pod optimized-build missing (0/3)."
-  fi
+	if resource_exists "pod" "optimized-build" "ward"; then
+		score=$((score + 3))
+		details+="Pod optimized-build found (3/3)."
+	else
+		details+="Pod optimized-build missing (0/3)."
+	fi
 
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q2() {
-  local score=0
-  local max_points=6
-  local details=""
+	local score=0
+	local max_points=6
+	local details=""
 
-  if resource_exists "pod" "logging-pod" "aegis"; then
-    score=$((score + 2))
-    details="Pod exists (2/2). "
-    local containers=$(kubectl get pod logging-pod -n aegis -o jsonpath='{.spec.containers[*].name}')
-    if [[ "$containers" == *"app-container"* ]] && [[ "$containers" == *"log-tailer"* ]]; then
-      score=$((score + 2))
-      details+="Containers exist (2/2). "
-    else
-      details+="Containers missing (0/2). "
-    fi
-    local requests=$(kubectl get pod logging-pod -n aegis -o jsonpath='{.spec.containers[?(@.name=="app-container")].resources.requests.cpu}')
-    if [[ -n "$requests" ]]; then
-      score=$((score + 2))
-      details+="Resources set (2/2)."
-    else
-      details+="Resources missing (0/2)."
-    fi
-  else
-    details="Pod missing (0/6)."
-  fi
+	if resource_exists "pod" "logging-pod" "aegis"; then
+		score=$((score + 2))
+		details="Pod exists (2/2). "
+		local containers=$(kubectl get pod logging-pod -n aegis -o jsonpath='{.spec.containers[*].name}')
+		if [[ "$containers" == *"app-container"* ]] && [[ "$containers" == *"log-tailer"* ]]; then
+			score=$((score + 2))
+			details+="Containers exist (2/2). "
+		else
+			details+="Containers missing (0/2). "
+		fi
+		local requests=$(kubectl get pod logging-pod -n aegis -o jsonpath='{.spec.containers[?(@.name=="app-container")].resources.requests.cpu}')
+		if [[ -n "$requests" ]]; then
+			score=$((score + 2))
+			details+="Resources set (2/2)."
+		else
+			details+="Resources missing (0/2)."
+		fi
+	else
+		details="Pod missing (0/6)."
+	fi
 
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q3() {
-  local score=0
-  local max_points=6
-  local details=""
+	local score=0
+	local max_points=6
+	local details=""
 
-  local sus=$(kubectl get cronjob backup-cj -n shield -o jsonpath='{.spec.suspend}')
-  if [[ "$sus" == "true" ]]; then
-    score=$((score + 3))
-    details="CronJob suspended (3/3). "
-  else
-    details="CronJob not suspended (0/3). "
-  fi
+	local sus=$(kubectl get cronjob backup-cj -n shield -o jsonpath='{.spec.suspend}')
+	if [[ "$sus" == "true" ]]; then
+		score=$((score + 3))
+		details="CronJob suspended (3/3). "
+	else
+		details="CronJob not suspended (0/3). "
+	fi
 
-  if resource_exists "job" "manual-backup" "shield"; then
-    score=$((score + 3))
-    details+="Manual job exists (3/3)."
-  else
-    details+="Manual job missing (0/3)."
-  fi
+	if resource_exists "job" "manual-backup" "shield"; then
+		score=$((score + 3))
+		details+="Manual job exists (3/3)."
+	else
+		details+="Manual job missing (0/3)."
+	fi
 
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q4() {
-  local score=0
-  local max_points=6
-  local details=""
+	local score=0
+	local max_points=6
+	local details=""
 
-  if resource_exists "pod" "init-chain" "guardian"; then
-    score=$((score + 2))
-    details="Pod exists (2/2). "
-    local init_count=$(kubectl get pod init-chain -n guardian -o jsonpath='{.spec.initContainers}' | grep -o name | wc -l)
-    if [ "$init_count" -ge 3 ]; then
-      score=$((score + 4))
-      details+="3 init containers found (4/4)."
-    else
-      details+="Not enough init containers (0/4)."
-    fi
-  else
-    details="Pod missing (0/6)."
-  fi
+	if resource_exists "pod" "init-chain" "guardian"; then
+		score=$((score + 2))
+		details="Pod exists (2/2). "
+		local init_count=$(kubectl get pod init-chain -n guardian -o jsonpath='{.spec.initContainers}' | grep -o name | wc -l)
+		if [ "$init_count" -ge 3 ]; then
+			score=$((score + 4))
+			details+="3 init containers found (4/4)."
+		else
+			details+="Not enough init containers (0/4)."
+		fi
+	else
+		details="Pod missing (0/6)."
+	fi
 
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q5() {
-  local score=0
-  local max_points=6
-  local details=""
+	local score=0
+	local max_points=6
+	local details=""
 
-  local reps=$(helm get values guardian-app -n haven -o json | grep replicaCount | grep -o '"replicaCount":[0-9]*' | grep -o '[0-9]*')
-  if [[ "$reps" == "3" ]]; then
-    score=$((score + 3))
-    details="Replica count updated to 3 (3/3). "
-  else
-    details="Replica count not updated (0/3). "
-  fi
+	local reps=$(helm get values guardian-app -n haven -o json | grep replicaCount | grep -o '"replicaCount":[0-9]*' | grep -o '[0-9]*')
+	if [[ "$reps" == "3" ]]; then
+		score=$((score + 3))
+		details="Replica count updated to 3 (3/3). "
+	else
+		details="Replica count not updated (0/3). "
+	fi
 
-  local img=$(helm get values guardian-app -n haven -o json | grep tag)
-  if [[ "$img" == *"latest"* ]]; then
-    score=$((score + 3))
-    details+="Image tag updated to latest (3/3)."
-  else
-    details+="Image tag not updated (0/3)."
-  fi
+	local img=$(helm get values guardian-app -n haven -o json | grep tag)
+	if [[ "$img" == *"latest"* ]]; then
+		score=$((score + 3))
+		details+="Image tag updated to latest (3/3)."
+	else
+		details+="Image tag not updated (0/3)."
+	fi
 
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q6() {
-  local score=0
-  local max_points=6
-  local details=""
+	local score=0
+	local max_points=6
+	local details=""
 
-  local target=$(kubectl get hpa api-hpa -n refuge -o jsonpath='{.spec.scaleTargetRef.name}')
-  if [[ "$target" == "api-server" ]]; then
-    score=$((score + 3))
-    details="HPA target fixed (3/3). "
-  else
-    details="HPA target wrong (0/3). "
-  fi
+	local target=$(kubectl get hpa api-hpa -n refuge -o jsonpath='{.spec.scaleTargetRef.name}')
+	if [[ "$target" == "api-server" ]]; then
+		score=$((score + 3))
+		details="HPA target fixed (3/3). "
+	else
+		details="HPA target wrong (0/3). "
+	fi
 
-  local min_reps=$(kubectl get hpa api-hpa -n refuge -o jsonpath='{.spec.minReplicas}')
-  if [[ "$min_reps" == "2" ]]; then
-    score=$((score + 3))
-    details+="HPA minReplicas fixed (3/3)."
-  else
-    details+="HPA minReplicas wrong (0/3)."
-  fi
+	local min_reps=$(kubectl get hpa api-hpa -n refuge -o jsonpath='{.spec.minReplicas}')
+	if [[ "$min_reps" == "2" ]]; then
+		score=$((score + 3))
+		details+="HPA minReplicas fixed (3/3)."
+	else
+		details+="HPA minReplicas wrong (0/3)."
+	fi
 
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q7() {
-  local score=0
-  local max_points=6
-  local details=""
+	local score=0
+	local max_points=6
+	local details=""
 
-  if resource_exists "deployment" "worker-deploy" "bastion"; then
-    local nginx_img=$(kubectl get deployment worker-deploy -n bastion -o jsonpath='{.spec.template.spec.containers[?(@.name=="nginx")].image}')
-    if [[ "$nginx_img" == "nginx:1.24.0" ]]; then
-      score=$((score + 3))
-      details="Nginx rollback successful (3/3). "
-    else
-      details="Nginx rollback failed (0/3). "
-    fi
-    local redis_img=$(kubectl get deployment worker-deploy -n bastion -o jsonpath='{.spec.template.spec.containers[?(@.name=="redis")].image}')
-    if [[ "$redis_img" == "redis:6.2" ]] || [[ "$redis_img" == "redis:7.0" ]]; then
-      score=$((score + 3))
-      details+="Redis container OK (3/3)."
-    else
-      details+="Redis container issue (0/3)."
-    fi
-  else
-    details="Deployment missing (0/6)."
-  fi
+	if resource_exists "deployment" "worker-deploy" "bastion"; then
+		local nginx_img=$(kubectl get deployment worker-deploy -n bastion -o jsonpath='{.spec.template.spec.containers[?(@.name=="nginx")].image}')
+		if [[ "$nginx_img" == "nginx:1.24.0" ]]; then
+			score=$((score + 3))
+			details="Nginx rollback successful (3/3). "
+		else
+			details="Nginx rollback failed (0/3). "
+		fi
+		local redis_img=$(kubectl get deployment worker-deploy -n bastion -o jsonpath='{.spec.template.spec.containers[?(@.name=="redis")].image}')
+		if [[ "$redis_img" == "redis:6.2" ]] || [[ "$redis_img" == "redis:7.0" ]]; then
+			score=$((score + 3))
+			details+="Redis container OK (3/3)."
+		else
+			details+="Redis container issue (0/3)."
+		fi
+	else
+		details="Deployment missing (0/6)."
+	fi
 
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q8() {
-  local score=0
-  local max_points=6
-  local details=""
+	local score=0
+	local max_points=6
+	local details=""
 
-  if resource_exists "deployment" "my-app" "bulwark"; then
-    score=$((score + 3))
-    details="Deployment applied to bulwark (3/3). "
-    local reps=$(kubectl get deployment my-app -n bulwark -o jsonpath='{.spec.replicas}')
-    if [[ "$reps" == "4" ]]; then
-      score=$((score + 3))
-      details+="Replicas patched to 4 (3/3)."
-    else
-      details+="Replicas not patched (0/3)."
-    fi
-  else
-    details="Deployment missing in bulwark (0/6)."
-  fi
+	if resource_exists "deployment" "my-app" "bulwark"; then
+		score=$((score + 3))
+		details="Deployment applied to bulwark (3/3). "
+		local reps=$(kubectl get deployment my-app -n bulwark -o jsonpath='{.spec.replicas}')
+		if [[ "$reps" == "4" ]]; then
+			score=$((score + 3))
+			details+="Replicas patched to 4 (3/3)."
+		else
+			details+="Replicas not patched (0/3)."
+		fi
+	else
+		details="Deployment missing in bulwark (0/6)."
+	fi
 
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q9() {
-  local score=0
-  local max_points=6
-  local details=""
+	local score=0
+	local max_points=6
+	local details=""
 
-  if resource_exists "secret" "app-secret" "anchor"; then
-    score=$((score + 2))
-    details="Secret created (2/2). "
-  else
-    details="Secret missing (0/2). "
-  fi
+	if resource_exists "secret" "app-secret" "anchor"; then
+		score=$((score + 2))
+		details="Secret created (2/2). "
+	else
+		details="Secret missing (0/2). "
+	fi
 
-  local img=$(kubectl get deployment broken-app -n anchor -o jsonpath='{.spec.template.spec.containers[0].image}')
-  if [[ "$img" == "nginx:1.25.0" ]]; then
-    score=$((score + 2))
-    details+="Image corrected (2/2). "
-  else
-    details+="Image incorrect (0/2). "
-  fi
+	local img=$(kubectl get deployment broken-app -n anchor -o jsonpath='{.spec.template.spec.containers[0].image}')
+	if [[ "$img" == "nginx:1.25.0" ]]; then
+		score=$((score + 2))
+		details+="Image corrected (2/2). "
+	else
+		details+="Image incorrect (0/2). "
+	fi
 
-  local port=$(kubectl get deployment broken-app -n anchor -o jsonpath='{.spec.template.spec.containers[0].ports[0].containerPort}')
-  if [[ "$port" == "80" ]]; then
-    score=$((score + 2))
-    details+="Port corrected (2/2)."
-  else
-    details+="Port incorrect (0/2)."
-  fi
+	local port=$(kubectl get deployment broken-app -n anchor -o jsonpath='{.spec.template.spec.containers[0].ports[0].containerPort}')
+	if [[ "$port" == "80" ]]; then
+		score=$((score + 2))
+		details+="Port corrected (2/2)."
+	else
+		details+="Port incorrect (0/2)."
+	fi
 
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q10() {
-  local score=0
-  local max_points=6
-  local details=""
+	local score=0
+	local max_points=6
+	local details=""
 
-  if [ -f "$EXAM_DIR/q10/cpu-usage.txt" ]; then
-    local content=$(cat "$EXAM_DIR/q10/cpu-usage.txt")
-    if [[ "$content" == *"backend-pod-"* ]]; then
-      score=$((score + 6))
-      details="File contains pod name (6/6)."
-    else
-      details="Incorrect pod name (0/6)."
-    fi
-  else
-    details="File missing (0/6)."
-  fi
+	if [ -f "$EXAM_DIR/q10/cpu-usage.txt" ]; then
+		local content=$(cat "$EXAM_DIR/q10/cpu-usage.txt")
+		if [[ "$content" == *"backend-pod-"* ]]; then
+			score=$((score + 6))
+			details="File contains pod name (6/6)."
+		else
+			details="Incorrect pod name (0/6)."
+		fi
+	else
+		details="File missing (0/6)."
+	fi
 
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q11() {
-  local score=0
-  local max_points=6
-  local details=""
+	local score=0
+	local max_points=6
+	local details=""
 
-  if resource_exists "pod" "monitored-pod" "ward"; then
-    score=$((score + 2))
-    details="Pod exists (2/2). "
-    local liveness=$(kubectl get pod monitored-pod -n ward -o jsonpath='{.spec.containers[0].livenessProbe}')
-    local readiness=$(kubectl get pod monitored-pod -n ward -o jsonpath='{.spec.containers[0].readinessProbe}')
-    local startup=$(kubectl get pod monitored-pod -n ward -o jsonpath='{.spec.containers[0].startupProbe}')
-    if [[ -n "$liveness" ]] && [[ -n "$readiness" ]] && [[ -n "$startup" ]]; then
-      score=$((score + 4))
-      details+="All probes present (4/4)."
-    else
-      details+="Probes missing (0/4)."
-    fi
-  else
-    details="Pod missing (0/6)."
-  fi
+	if resource_exists "pod" "monitored-pod" "ward"; then
+		score=$((score + 2))
+		details="Pod exists (2/2). "
+		local liveness=$(kubectl get pod monitored-pod -n ward -o jsonpath='{.spec.containers[0].livenessProbe}')
+		local readiness=$(kubectl get pod monitored-pod -n ward -o jsonpath='{.spec.containers[0].readinessProbe}')
+		local startup=$(kubectl get pod monitored-pod -n ward -o jsonpath='{.spec.containers[0].startupProbe}')
+		if [[ -n "$liveness" ]] && [[ -n "$readiness" ]] && [[ -n "$startup" ]]; then
+			score=$((score + 4))
+			details+="All probes present (4/4)."
+		else
+			details+="Probes missing (0/4)."
+		fi
+	else
+		details="Pod missing (0/6)."
+	fi
 
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q12() {
-  local score=0
-  local max_points=6
-  local details=""
+	local score=0
+	local max_points=6
+	local details=""
 
-  if resource_exists "configmap" "app-config" "aegis"; then
-    score=$((score + 3))
-    details="ConfigMap exists (3/3). "
-  else
-    details="ConfigMap missing (0/3). "
-  fi
+	if resource_exists "configmap" "app-config" "aegis"; then
+		score=$((score + 3))
+		details="ConfigMap exists (3/3). "
+	else
+		details="ConfigMap missing (0/3). "
+	fi
 
-  if resource_exists "pod" "config-pod" "aegis"; then
-    score=$((score + 3))
-    details+="Pod exists (3/3)."
-  else
-    details+="Pod missing (0/3)."
-  fi
+	if resource_exists "pod" "config-pod" "aegis"; then
+		score=$((score + 3))
+		details+="Pod exists (3/3)."
+	else
+		details+="Pod missing (0/3)."
+	fi
 
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q13() {
-  local score=0
-  local max_points=6
-  local details=""
+	local score=0
+	local max_points=6
+	local details=""
 
-  if resource_exists "sa" "vault-sa" "shield"; then
-    score=$((score + 3))
-    details="ServiceAccount exists (3/3). "
-  else
-    details="ServiceAccount missing (0/3). "
-  fi
+	if resource_exists "sa" "vault-sa" "shield"; then
+		score=$((score + 3))
+		details="ServiceAccount exists (3/3). "
+	else
+		details="ServiceAccount missing (0/3). "
+	fi
 
-  if [ -f "$EXAM_DIR/q13/token.txt" ]; then
-    local ts=$(wc -c < "$EXAM_DIR/q13/token.txt")
-    if [ "$ts" -gt 100 ]; then
-      score=$((score + 3))
-      details+="Token looks valid (3/3)."
-    else
-      details+="Token file empty or invalid (0/3)."
-    fi
-  else
-    details+="Token file missing (0/3)."
-  fi
+	if [ -f "$EXAM_DIR/q13/token.txt" ]; then
+		local ts=$(wc -c <"$EXAM_DIR/q13/token.txt")
+		if [ "$ts" -gt 100 ]; then
+			score=$((score + 3))
+			details+="Token looks valid (3/3)."
+		else
+			details+="Token file empty or invalid (0/3)."
+		fi
+	else
+		details+="Token file missing (0/3)."
+	fi
 
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q14() {
-  local score=0
-  local max_points=6
-  local details=""
+	local score=0
+	local max_points=6
+	local details=""
 
-  if resource_exists "pod" "secure-pod" "guardian"; then
-    local p_user=$(kubectl get pod secure-pod -n guardian -o jsonpath='{.spec.securityContext.runAsUser}')
-    if [[ "$p_user" == "1000" ]]; then
-      score=$((score + 3))
-      details="Pod SecurityContext OK (3/3). "
-    else
-      details="Pod SecurityContext wrong (0/3). "
-    fi
+	if resource_exists "pod" "secure-pod" "guardian"; then
+		local p_user=$(kubectl get pod secure-pod -n guardian -o jsonpath='{.spec.securityContext.runAsUser}')
+		if [[ "$p_user" == "1000" ]]; then
+			score=$((score + 3))
+			details="Pod SecurityContext OK (3/3). "
+		else
+			details="Pod SecurityContext wrong (0/3). "
+		fi
 
-    local c_user=$(kubectl get pod secure-pod -n guardian -o jsonpath='{.spec.containers[0].securityContext.runAsUser}')
-    if [[ "$c_user" == "2000" ]]; then
-      score=$((score + 3))
-      details+="Container SecurityContext OK (3/3)."
-    else
-      details+="Container SecurityContext wrong (0/3)."
-    fi
-  else
-    details="Pod missing (0/6)."
-  fi
+		local c_user=$(kubectl get pod secure-pod -n guardian -o jsonpath='{.spec.containers[0].securityContext.runAsUser}')
+		if [[ "$c_user" == "2000" ]]; then
+			score=$((score + 3))
+			details+="Container SecurityContext OK (3/3)."
+		else
+			details+="Container SecurityContext wrong (0/3)."
+		fi
+	else
+		details="Pod missing (0/6)."
+	fi
 
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q15() {
-  local score=0
-  local max_points=6
-  local details=""
+	local score=0
+	local max_points=6
+	local details=""
 
-  if resource_exists "role" "config-editor" "haven"; then
-    local rnames=$(kubectl get role config-editor -n haven -o jsonpath='{.rules[0].resourceNames}')
-    if [[ "$rnames" == *"primary-config"* ]]; then
-      score=$((score + 3))
-      details="Role correctly targets resourceNames (3/3). "
-    else
-      details="Role missing resourceNames (0/3). "
-    fi
-  else
-    details="Role missing (0/3). "
-  fi
+	if resource_exists "role" "config-editor" "haven"; then
+		local rnames=$(kubectl get role config-editor -n haven -o jsonpath='{.rules[0].resourceNames}')
+		if [[ "$rnames" == *"primary-config"* ]]; then
+			score=$((score + 3))
+			details="Role correctly targets resourceNames (3/3). "
+		else
+			details="Role missing resourceNames (0/3). "
+		fi
+	else
+		details="Role missing (0/3). "
+	fi
 
-  if resource_exists "rolebinding" "dev-config-binding" "haven"; then
-    score=$((score + 3))
-    details+="RoleBinding exists (3/3)."
-  else
-    details+="RoleBinding missing (0/3)."
-  fi
+	if resource_exists "rolebinding" "dev-config-binding" "haven"; then
+		score=$((score + 3))
+		details+="RoleBinding exists (3/3)."
+	else
+		details+="RoleBinding missing (0/3)."
+	fi
 
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q16() {
-  local score=0
-  local max_points=6
-  local details=""
+	local score=0
+	local max_points=6
+	local details=""
 
-  local enf=$(kubectl get ns refuge -o jsonpath='{.metadata.labels.pod-security\.kubernetes\.io/enforce}')
-  if [[ "$enf" == "restricted" ]]; then
-    score=$((score + 3))
-    details="Enforce restricted label present (3/3). "
-  else
-    details="Enforce restricted label missing (0/3). "
-  fi
+	local enf=$(kubectl get ns refuge -o jsonpath='{.metadata.labels.pod-security\.kubernetes\.io/enforce}')
+	if [[ "$enf" == "restricted" ]]; then
+		score=$((score + 3))
+		details="Enforce restricted label present (3/3). "
+	else
+		details="Enforce restricted label missing (0/3). "
+	fi
 
-  local wrn=$(kubectl get ns refuge -o jsonpath='{.metadata.labels.pod-security\.kubernetes\.io/warn}')
-  if [[ "$wrn" == "baseline" ]]; then
-    score=$((score + 3))
-    details+="Warn baseline label present (3/3)."
-  else
-    details+="Warn baseline label missing (0/3)."
-  fi
+	local wrn=$(kubectl get ns refuge -o jsonpath='{.metadata.labels.pod-security\.kubernetes\.io/warn}')
+	if [[ "$wrn" == "baseline" ]]; then
+		score=$((score + 3))
+		details+="Warn baseline label present (3/3)."
+	else
+		details+="Warn baseline label missing (0/3)."
+	fi
 
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q17() {
-  local score=0
-  local max_points=6
-  local details=""
+	local score=0
+	local max_points=6
+	local details=""
 
-  if resource_exists "networkpolicy" "db-protect" "bastion"; then
-    score=$((score + 6))
-    details="NetworkPolicy db-protect exists (6/6)."
-  else
-    details="NetworkPolicy db-protect missing (0/6)."
-  fi
+	if resource_exists "networkpolicy" "db-protect" "bastion"; then
+		score=$((score + 6))
+		details="NetworkPolicy db-protect exists (6/6)."
+	else
+		details="NetworkPolicy db-protect missing (0/6)."
+	fi
 
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q18() {
-  local score=0
-  local max_points=6
-  local details=""
+	local score=0
+	local max_points=6
+	local details=""
 
-  if resource_exists "ingress" "regex-ingress" "bulwark"; then
-    score=$((score + 3))
-    details="Ingress exists (3/3). "
-    local anno=$(kubectl get ingress regex-ingress -n bulwark -o jsonpath='{.metadata.annotations}')
-    if [[ "$anno" == *"use-regex"* ]]; then
-      score=$((score + 3))
-      details+="Regex annotation present (3/3)."
-    else
-      details+="Regex annotation missing (0/3)."
-    fi
-  else
-    details="Ingress missing (0/6)."
-  fi
+	if resource_exists "ingress" "regex-ingress" "bulwark"; then
+		score=$((score + 3))
+		details="Ingress exists (3/3). "
+		local anno=$(kubectl get ingress regex-ingress -n bulwark -o jsonpath='{.metadata.annotations}')
+		if [[ "$anno" == *"use-regex"* ]]; then
+			score=$((score + 3))
+			details+="Regex annotation present (3/3)."
+		else
+			details+="Regex annotation missing (0/3)."
+		fi
+	else
+		details="Ingress missing (0/6)."
+	fi
 
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q19() {
-  local score=0
-  local max_points=6
-  local details=""
+	local score=0
+	local max_points=6
+	local details=""
 
-  if resource_exists "service" "topology-service" "anchor"; then
-    score=$((score + 3))
-    details="Service exists (3/3). "
-    local anno=$(kubectl get service topology-service -n anchor -o jsonpath='{.metadata.annotations}')
-    if [[ "$anno" == *"topology"* ]]; then
-      score=$((score + 3))
-      details+="Topology annotation present (3/3)."
-    else
-      details+="Topology annotation missing (0/3)."
-    fi
-  else
-    details="Service missing (0/6)."
-  fi
+	if resource_exists "service" "topology-service" "anchor"; then
+		score=$((score + 3))
+		details="Service exists (3/3). "
+		local anno=$(kubectl get service topology-service -n anchor -o jsonpath='{.metadata.annotations}')
+		if [[ "$anno" == *"topology"* ]]; then
+			score=$((score + 3))
+			details+="Topology annotation present (3/3)."
+		else
+			details+="Topology annotation missing (0/3)."
+		fi
+	else
+		details="Service missing (0/6)."
+	fi
 
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q20() {
-  local score=0
-  local max_points=6
-  local details=""
+	local score=0
+	local max_points=6
+	local details=""
 
-  if resource_exists "networkpolicy" "strict-net" "helm"; then
-    score=$((score + 6))
-    details="NetworkPolicy strict-net exists (6/6)."
-  else
-    details="NetworkPolicy strict-net missing (0/6)."
-  fi
+	if resource_exists "networkpolicy" "strict-net" "helm"; then
+		score=$((score + 6))
+		details="NetworkPolicy strict-net exists (6/6)."
+	else
+		details="NetworkPolicy strict-net missing (0/6)."
+	fi
 
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }

--- a/exams/ckad-simulation19/solutions.md
+++ b/exams/ckad-simulation19/solutions.md
@@ -4,7 +4,7 @@
 
 ## Question 1 | Kubernetes Practice
 
-**Explanation**: 
+**Explanation**:
 Multi-stage builds reduce image size and improve security. We create a builder stage and a final stage.
 
 ```bash

--- a/exams/ckad-simulation20/post-setup.sh
+++ b/exams/ckad-simulation20/post-setup.sh
@@ -1,20 +1,20 @@
 #!/bin/bash
 exam_post_setup() {
-  local BASE_DIR="./exam/course"
-  mkdir -p "$BASE_DIR/1" "$BASE_DIR/2" "$BASE_DIR/3" "$BASE_DIR/4" "$BASE_DIR/5" "$BASE_DIR/6" "$BASE_DIR/7" "$BASE_DIR/8/base" "$BASE_DIR/8/prod" "$BASE_DIR/10" "$BASE_DIR/12" "$BASE_DIR/13" "$BASE_DIR/14" "$BASE_DIR/15" "$BASE_DIR/16" "$BASE_DIR/17" "$BASE_DIR/18" "$BASE_DIR/19" "$BASE_DIR/20"
+	local BASE_DIR="./exam/course"
+	mkdir -p "$BASE_DIR/1" "$BASE_DIR/2" "$BASE_DIR/3" "$BASE_DIR/4" "$BASE_DIR/5" "$BASE_DIR/6" "$BASE_DIR/7" "$BASE_DIR/8/base" "$BASE_DIR/8/prod" "$BASE_DIR/10" "$BASE_DIR/12" "$BASE_DIR/13" "$BASE_DIR/14" "$BASE_DIR/15" "$BASE_DIR/16" "$BASE_DIR/17" "$BASE_DIR/18" "$BASE_DIR/19" "$BASE_DIR/20"
 
-  cat << 'EOF2' > "$BASE_DIR/1/main.go"
+	cat <<'EOF2' >"$BASE_DIR/1/main.go"
 package main
 import "fmt"
 func main() { fmt.Println("Hello Dojo") }
 EOF2
-  cat << 'EOF2' > "$BASE_DIR/1/Dockerfile"
+	cat <<'EOF2' >"$BASE_DIR/1/Dockerfile"
 FROM nginx:alpine
 # TODO
 EOF2
-  
-  for q in 2/multi-pod 6/deploy 7/canary 12/secure-pod 14/inject 19/svc 20/dns; do
-    cat << 'EOF2' > "$BASE_DIR/${q}.yaml"
+
+	for q in 2/multi-pod 6/deploy 7/canary 12/secure-pod 14/inject 19/svc 20/dns; do
+		cat <<'EOF2' >"$BASE_DIR/${q}.yaml"
 apiVersion: v1
 kind: Pod
 metadata:
@@ -24,17 +24,9 @@ spec:
   - name: c
     image: nginx
 EOF2
-  done
+	done
 
-  
-  
-  mkdir -p "$BASE_DIR/5/my-chart"
-  
-  
-  
-  
-  
-  
-  
-  return 0
+	mkdir -p "$BASE_DIR/5/my-chart"
+
+	return 0
 }

--- a/exams/ckad-simulation20/questions.md
+++ b/exams/ckad-simulation20/questions.md
@@ -26,6 +26,7 @@
 | **File to create** | `./exam/course/1/Dockerfile`<br>`./exam/course/1/pod.yaml` |
 
 ### Task
+
 Create an optimized Dockerfile that builds a Go application using multi-stage builds. Use the source code provided in `./exam/course/1/main.go`. The final image should be based on `alpine:latest` and run as a non-root user (UID 1000). Tag the image as `localhost:5000/musashi-app:v1`.
 Then create a pod named `musashi-pod` in the `apex` namespace using this image.
 
@@ -43,7 +44,9 @@ Then create a pod named `musashi-pod` in the `apex` namespace using this image.
 | **File to create** | `./exam/course/2/multi-pod.yaml` |
 
 ### Task
+
 Create a multi-container pod named `tri-blade` in the `summit` namespace with three containers:
+
 1. `main`: image `nginx:1.24`, mounts a shared emptyDir volume at `/var/log/nginx`
 2. `sidecar`: image `busybox`, writes current time to `/shared/time.log` every 5 seconds (volume mounted at `/shared`)
 3. `adapter`: image `fluentd`, tails `/var/log/shared/time.log` (volume mounted at `/var/log/shared`)
@@ -62,6 +65,7 @@ Create a multi-container pod named `tri-blade` in the `summit` namespace with th
 | **File to create** | `./exam/course/3/job.yaml` |
 
 ### Task
+
 Create a Job named `data-processor` in the `pinnacle` namespace.
 The job should calculate the value of pi using the `perl` image: `perl -Mbignum=bpi -wle 'print bpi(2000)'`.
 Configure the Job to complete 3 successful pods, with 2 running in parallel.
@@ -80,6 +84,7 @@ Configure the Job to complete 3 successful pods, with 2 running in parallel.
 | **File to create** | `./exam/course/4/cronjob.yaml` |
 
 ### Task
+
 Create a CronJob named `db-backup` in the `zenith` namespace.
 Schedule: every 15 minutes (`*/15 * * * *`).
 Image: `postgres:15`.
@@ -100,6 +105,7 @@ Retain 3 successful jobs and 1 failed job.
 | **File to create** | `./exam/course/5/values.yaml` |
 
 ### Task
+
 Create a Helm chart named `my-chart` from scratch in `./exam/course/5/my-chart`.
 Create a `values.yaml` in `./exam/course/5/` that overrides the replica count to 3 and the image repository to `nginx` and tag to `alpine`.
 Install the chart into the `crown` namespace with the release name `crown-release`.
@@ -118,6 +124,7 @@ Install the chart into the `crown` namespace with the release name `crown-releas
 | **File to create** | `./exam/course/6/deploy.yaml` |
 
 ### Task
+
 A deployment `glory-deploy` exists in the `glory` namespace.
 Update its image to `nginx:1.25` and record the change.
 Then rollback the deployment to the previous revision.
@@ -137,6 +144,7 @@ Finally, scale it to 5 replicas.
 | **File to create** | `./exam/course/7/canary.yaml` |
 
 ### Task
+
 Implement a canary deployment in the `legacy` namespace.
 Create a new deployment `legacy-canary` alongside the existing `legacy-main` deployment.
 The canary should have 1 replica using `httpd:2.4`, while the main has 4. Ensure they both have the label `app=legacy-web` so the existing service routes 20% of traffic to the canary.
@@ -155,9 +163,11 @@ The canary should have 1 replica using `httpd:2.4`, while the main has 4. Ensure
 | **File to create** | `./exam/course/8/kustomization.yaml` |
 
 ### Task
+
 Use Kustomize in `./exam/course/8/`.
 Base exists in `./exam/course/8/base`. Create a production overlay in `./exam/course/8/prod`.
 The overlay should:
+
 - Add a label `env=prod`
 - Change replica count to 4
 - Apply the generated resources to the `mastery` namespace.
@@ -175,6 +185,7 @@ The overlay should:
 | **Resources** | Pods |
 
 ### Task
+
 There are 3 broken pods in the `ascend` namespace: `bug-1`, `bug-2`, and `bug-3`.
 Troubleshoot and fix them. (You may delete and recreate if necessary, or edit them in place).
 
@@ -192,6 +203,7 @@ Troubleshoot and fix them. (You may delete and recreate if necessary, or edit th
 | **File to create** | `./exam/course/10/logs.txt` |
 
 ### Task
+
 Extract the logs from the `triumph-app` pod in the `triumph` namespace.
 Find all lines containing "ERROR" and save them to `./exam/course/10/logs.txt`.
 
@@ -208,6 +220,7 @@ Find all lines containing "ERROR" and save them to `./exam/course/10/logs.txt`.
 | **Resources** | Debug |
 
 ### Task
+
 Use an ephemeral debug container to troubleshoot `distroless-pod` in the `apex` namespace.
 Attach an ephemeral container using the `busybox` image and run `nslookup kubernetes.default`.
 
@@ -225,6 +238,7 @@ Attach an ephemeral container using the `busybox` image and run `nslookup kubern
 | **File to create** | `./exam/course/12/secure-pod.yaml` |
 
 ### Task
+
 Create a pod `secure-pod` in the `summit` namespace.
 Image: `nginx`.
 Container security context: `runAsUser: 2000`, `allowPrivilegeEscalation: false`, drop `ALL` capabilities, add `NET_BIND_SERVICE`.
@@ -243,6 +257,7 @@ Container security context: `runAsUser: 2000`, `allowPrivilegeEscalation: false`
 | **File to create** | `./exam/course/13/rbac.yaml` |
 
 ### Task
+
 Create a ServiceAccount `sword-master` in `pinnacle`.
 Create a Role `blade-reader` that can get, list, watch pods and configmaps.
 Create a RoleBinding `master-binding` binding the role to the service account.
@@ -261,6 +276,7 @@ Create a RoleBinding `master-binding` binding the role to the service account.
 | **File to create** | `./exam/course/14/inject.yaml` |
 
 ### Task
+
 Create a ConfigMap `app-config` with `THEME=dark`.
 Create a Secret `app-secret` with `API_KEY=musashi123`.
 Create a pod `inject-pod` in `zenith` that uses `app-config` as environment variables and mounts `app-secret` at `/etc/secret/`.
@@ -279,6 +295,7 @@ Create a pod `inject-pod` in `zenith` that uses `app-config` as environment vari
 | **File to create** | `./exam/course/15/quota.yaml` |
 
 ### Task
+
 Create a LimitRange `cpu-limits` in `crown`: default 500m, defaultRequest 200m for CPU.
 Create a ResourceQuota `compute-quota` in `crown`: max 4 pods, max 2 CPU, max 4Gi memory.
 
@@ -296,6 +313,7 @@ Create a ResourceQuota `compute-quota` in `crown`: max 4 pods, max 2 CPU, max 4G
 | **File to create** | `./exam/course/16/storage.yaml` |
 
 ### Task
+
 Create a PV `glory-pv` (1Gi, hostPath `/data/glory`, ReadWriteOnce).
 Create a PVC `glory-pvc` (500Mi, ReadWriteOnce) in `glory`.
 Create a pod `glory-pod` that mounts this PVC at `/var/data`.
@@ -314,6 +332,7 @@ Create a pod `glory-pod` that mounts this PVC at `/var/data`.
 | **File to create** | `./exam/course/17/netpol.yaml` |
 
 ### Task
+
 In the `legacy` namespace, create a default deny-all NetworkPolicy.
 Then create a NetworkPolicy `allow-web` that allows ingress traffic to pods with `app=web` ONLY from pods with `app=api` on port 80.
 
@@ -331,6 +350,7 @@ Then create a NetworkPolicy `allow-web` that allows ingress traffic to pods with
 | **File to create** | `./exam/course/18/ingress.yaml` |
 
 ### Task
+
 Create an Ingress `mastery-ing` in `mastery`.
 Rule: Host `musashi.com`, path `/api` (prefix) routes to service `api-svc` on port 8080.
 Path `/web` (prefix) routes to service `web-svc` on port 80.
@@ -349,6 +369,7 @@ Path `/web` (prefix) routes to service `web-svc` on port 80.
 | **File to create** | `./exam/course/19/svc.yaml` |
 
 ### Task
+
 Create a NodePort service `ascend-svc` in `ascend` exposing port 80, targetPort 80, nodePort 30080. It should select pods with `app=ascend-app`.
 
 ---
@@ -365,5 +386,5 @@ Create a NodePort service `ascend-svc` in `ascend` exposing port 80, targetPort 
 | **File to create** | `./exam/course/20/dns.yaml` |
 
 ### Task
-Create a pod `dns-test` in `triumph`. Run a command to lookup the SRV record for the `kubernetes.default` service and save the output to `./exam/course/20/dns-output.txt`.
 
+Create a pod `dns-test` in `triumph`. Run a command to lookup the SRV record for the `kubernetes.default` service and save the output to `./exam/course/20/dns-output.txt`.

--- a/exams/ckad-simulation20/scoring-functions.sh
+++ b/exams/ckad-simulation20/scoring-functions.sh
@@ -8,377 +8,377 @@ source "$SCRIPT_DIR/../../scripts/lib/common.sh" 2>/dev/null || true
 EXAM_DIR="./exam/course"
 
 score_q1() {
-  local score=0
-  local max_points=6
-  local details=""
-  if resource_exists pod musashi-pod apex; then
-    score=$((score + 2))
-    details+="Pod musashi-pod exists. "
-    local image=$(kubectl get pod musashi-pod -n apex -o jsonpath='{.spec.containers[0].image}')
-    if [[ "$image" == "localhost:5000/musashi-app:v1" ]]; then
-      score=$((score + 4))
-      details+="Image is correct. "
-    else
-      details+="Image is incorrect. "
-    fi
-  else
-    details+="Pod musashi-pod not found. "
-  fi
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+	local score=0
+	local max_points=6
+	local details=""
+	if resource_exists pod musashi-pod apex; then
+		score=$((score + 2))
+		details+="Pod musashi-pod exists. "
+		local image=$(kubectl get pod musashi-pod -n apex -o jsonpath='{.spec.containers[0].image}')
+		if [[ "$image" == "localhost:5000/musashi-app:v1" ]]; then
+			score=$((score + 4))
+			details+="Image is correct. "
+		else
+			details+="Image is incorrect. "
+		fi
+	else
+		details+="Pod musashi-pod not found. "
+	fi
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q2() {
-  local score=0
-  local max_points=6
-  local details=""
-  if resource_exists pod tri-blade summit; then
-    score=$((score + 2))
-    details+="Pod tri-blade exists. "
-    local containers=$(kubectl get pod tri-blade -n summit -o jsonpath='{.spec.containers[*].name}')
-    if [[ "$containers" == *"main"* && "$containers" == *"sidecar"* && "$containers" == *"adapter"* ]]; then
-      score=$((score + 4))
-      details+="Containers exist. "
-    else
-      details+="Containers mismatch. "
-    fi
-  else
-    details+="Pod tri-blade not found. "
-  fi
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+	local score=0
+	local max_points=6
+	local details=""
+	if resource_exists pod tri-blade summit; then
+		score=$((score + 2))
+		details+="Pod tri-blade exists. "
+		local containers=$(kubectl get pod tri-blade -n summit -o jsonpath='{.spec.containers[*].name}')
+		if [[ "$containers" == *"main"* && "$containers" == *"sidecar"* && "$containers" == *"adapter"* ]]; then
+			score=$((score + 4))
+			details+="Containers exist. "
+		else
+			details+="Containers mismatch. "
+		fi
+	else
+		details+="Pod tri-blade not found. "
+	fi
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q3() {
-  local score=0
-  local max_points=6
-  local details=""
-  if resource_exists job data-processor pinnacle; then
-    score=$((score + 2))
-    details+="Job data-processor exists. "
-    local completions=$(kubectl get job data-processor -n pinnacle -o jsonpath='{.spec.completions}')
-    local parallelism=$(kubectl get job data-processor -n pinnacle -o jsonpath='{.spec.parallelism}')
-    if [[ "$completions" == "3" && "$parallelism" == "2" ]]; then
-      score=$((score + 4))
-      details+="Completions and parallelism correct. "
-    else
-      details+="Incorrect completions or parallelism. "
-    fi
-  else
-    details+="Job data-processor not found. "
-  fi
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+	local score=0
+	local max_points=6
+	local details=""
+	if resource_exists job data-processor pinnacle; then
+		score=$((score + 2))
+		details+="Job data-processor exists. "
+		local completions=$(kubectl get job data-processor -n pinnacle -o jsonpath='{.spec.completions}')
+		local parallelism=$(kubectl get job data-processor -n pinnacle -o jsonpath='{.spec.parallelism}')
+		if [[ "$completions" == "3" && "$parallelism" == "2" ]]; then
+			score=$((score + 4))
+			details+="Completions and parallelism correct. "
+		else
+			details+="Incorrect completions or parallelism. "
+		fi
+	else
+		details+="Job data-processor not found. "
+	fi
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q4() {
-  local score=0
-  local max_points=6
-  local details=""
-  if resource_exists cronjob db-backup zenith; then
-    score=$((score + 2))
-    details+="CronJob db-backup exists. "
-    local schedule=$(kubectl get cronjob db-backup -n zenith -o jsonpath='{.spec.schedule}')
-    if [[ "$schedule" == "*/15 * * * *" ]]; then
-      score=$((score + 4))
-      details+="Schedule correct. "
-    else
-      details+="Schedule incorrect. "
-    fi
-  else
-    details+="CronJob db-backup not found. "
-  fi
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+	local score=0
+	local max_points=6
+	local details=""
+	if resource_exists cronjob db-backup zenith; then
+		score=$((score + 2))
+		details+="CronJob db-backup exists. "
+		local schedule=$(kubectl get cronjob db-backup -n zenith -o jsonpath='{.spec.schedule}')
+		if [[ "$schedule" == "*/15 * * * *" ]]; then
+			score=$((score + 4))
+			details+="Schedule correct. "
+		else
+			details+="Schedule incorrect. "
+		fi
+	else
+		details+="CronJob db-backup not found. "
+	fi
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q5() {
-  local score=0
-  local max_points=6
-  local details=""
-  if helm ls -n crown | grep -q "crown-release"; then
-    score=$((score + 6))
-    details+="Helm release crown-release exists. "
-  else
-    details+="Helm release crown-release not found. "
-  fi
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+	local score=0
+	local max_points=6
+	local details=""
+	if helm ls -n crown | grep -q "crown-release"; then
+		score=$((score + 6))
+		details+="Helm release crown-release exists. "
+	else
+		details+="Helm release crown-release not found. "
+	fi
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q6() {
-  local score=0
-  local max_points=6
-  local details=""
-  if resource_exists deployment glory-deploy glory; then
-    score=$((score + 2))
-    details+="Deployment glory-deploy exists. "
-    local image=$(kubectl get deployment glory-deploy -n glory -o jsonpath='{.spec.template.spec.containers[0].image}')
-    local replicas=$(kubectl get deployment glory-deploy -n glory -o jsonpath='{.spec.replicas}')
-    if [[ "$image" == "nginx:1.25" || "$image" == "nginx" ]]; then
-      score=$((score + 2))
-      details+="Image updated. "
-    fi
-    if [[ "$replicas" == "5" ]]; then
-      score=$((score + 2))
-      details+="Replicas correct. "
-    fi
-  else
-    details+="Deployment glory-deploy not found. "
-  fi
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+	local score=0
+	local max_points=6
+	local details=""
+	if resource_exists deployment glory-deploy glory; then
+		score=$((score + 2))
+		details+="Deployment glory-deploy exists. "
+		local image=$(kubectl get deployment glory-deploy -n glory -o jsonpath='{.spec.template.spec.containers[0].image}')
+		local replicas=$(kubectl get deployment glory-deploy -n glory -o jsonpath='{.spec.replicas}')
+		if [[ "$image" == "nginx:1.25" || "$image" == "nginx" ]]; then
+			score=$((score + 2))
+			details+="Image updated. "
+		fi
+		if [[ "$replicas" == "5" ]]; then
+			score=$((score + 2))
+			details+="Replicas correct. "
+		fi
+	else
+		details+="Deployment glory-deploy not found. "
+	fi
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q7() {
-  local score=0
-  local max_points=6
-  local details=""
-  if resource_exists deployment legacy-canary legacy; then
-    score=$((score + 3))
-    details+="Canary deployment exists. "
-    local labels=$(kubectl get deployment legacy-canary -n legacy -o jsonpath='{.spec.template.metadata.labels.app}')
-    if [[ "$labels" == "legacy-web" ]]; then
-      score=$((score + 3))
-      details+="Labels match main deployment. "
-    else
-      details+="Labels do not match legacy-web. "
-    fi
-  else
-    details+="Canary deployment not found. "
-  fi
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+	local score=0
+	local max_points=6
+	local details=""
+	if resource_exists deployment legacy-canary legacy; then
+		score=$((score + 3))
+		details+="Canary deployment exists. "
+		local labels=$(kubectl get deployment legacy-canary -n legacy -o jsonpath='{.spec.template.metadata.labels.app}')
+		if [[ "$labels" == "legacy-web" ]]; then
+			score=$((score + 3))
+			details+="Labels match main deployment. "
+		else
+			details+="Labels do not match legacy-web. "
+		fi
+	else
+		details+="Canary deployment not found. "
+	fi
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q8() {
-  local score=0
-  local max_points=6
-  local details=""
-  if resource_exists deployment my-app mastery; then
-    score=$((score + 3))
-    details+="Deployment my-app applied in mastery. "
-    local labels=$(kubectl get deployment my-app -n mastery -o jsonpath='{.metadata.labels.env}')
-    if [[ "$labels" == "prod" ]]; then
-      score=$((score + 3))
-      details+="Label env=prod applied by Kustomize. "
-    else
-      details+="Label env=prod not found. "
-    fi
-  else
-    details+="Deployment my-app not found. "
-  fi
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+	local score=0
+	local max_points=6
+	local details=""
+	if resource_exists deployment my-app mastery; then
+		score=$((score + 3))
+		details+="Deployment my-app applied in mastery. "
+		local labels=$(kubectl get deployment my-app -n mastery -o jsonpath='{.metadata.labels.env}')
+		if [[ "$labels" == "prod" ]]; then
+			score=$((score + 3))
+			details+="Label env=prod applied by Kustomize. "
+		else
+			details+="Label env=prod not found. "
+		fi
+	else
+		details+="Deployment my-app not found. "
+	fi
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q9() {
-  local score=0
-  local max_points=6
-  local details=""
-  local count=$(kubectl get pods -n ascend --field-selector=status.phase=Running 2>/dev/null | grep -E "bug-[123]" | wc -l || echo "0")
-  if [[ "$count" -eq 3 ]]; then
-    score=6
-    details+="All 3 broken pods are now running. "
-  else
-    score=$((count * 2))
-    details+="$count/3 broken pods are running. "
-  fi
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+	local score=0
+	local max_points=6
+	local details=""
+	local count=$(kubectl get pods -n ascend --field-selector=status.phase=Running 2>/dev/null | grep -E "bug-[123]" | wc -l || echo "0")
+	if [[ "$count" -eq 3 ]]; then
+		score=6
+		details+="All 3 broken pods are now running. "
+	else
+		score=$((count * 2))
+		details+="$count/3 broken pods are running. "
+	fi
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q10() {
-  local score=0
-  local max_points=6
-  local details=""
-  if [ -f "./exam/course/10/logs.txt" ] || [ -f "./exam/course/10/logs.txt" ]; then
-    score=$((score + 3))
-    details+="File logs.txt created. "
-    if grep -q "ERROR" ./exam/course/10/logs.txt 2>/dev/null || grep -q "ERROR" ./exam/course/10/logs.txt 2>/dev/null; then
-      score=$((score + 3))
-      details+="Contains ERROR. "
-    else
-      details+="No ERROR found in file. "
-    fi
-  else
-    details+="File logs.txt not found. "
-  fi
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+	local score=0
+	local max_points=6
+	local details=""
+	if [ -f "./exam/course/10/logs.txt" ] || [ -f "./exam/course/10/logs.txt" ]; then
+		score=$((score + 3))
+		details+="File logs.txt created. "
+		if grep -q "ERROR" ./exam/course/10/logs.txt 2>/dev/null || grep -q "ERROR" ./exam/course/10/logs.txt 2>/dev/null; then
+			score=$((score + 3))
+			details+="Contains ERROR. "
+		else
+			details+="No ERROR found in file. "
+		fi
+	else
+		details+="File logs.txt not found. "
+	fi
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q11() {
-  local score=0
-  local max_points=6
-  local details=""
-  local eph=$(kubectl get pod distroless-pod -n apex -o jsonpath='{.spec.ephemeralContainers}' 2>/dev/null)
-  if [[ -n "$eph" && "$eph" != "[]" ]]; then
-    score=6
-    details+="Ephemeral container found. "
-  else
-    details+="No ephemeral container found on distroless-pod. "
-  fi
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+	local score=0
+	local max_points=6
+	local details=""
+	local eph=$(kubectl get pod distroless-pod -n apex -o jsonpath='{.spec.ephemeralContainers}' 2>/dev/null)
+	if [[ -n "$eph" && "$eph" != "[]" ]]; then
+		score=6
+		details+="Ephemeral container found. "
+	else
+		details+="No ephemeral container found on distroless-pod. "
+	fi
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q12() {
-  local score=0
-  local max_points=6
-  local details=""
-  if resource_exists pod secure-pod summit; then
-    score=$((score + 2))
-    details+="Pod secure-pod exists. "
-    local user=$(kubectl get pod secure-pod -n summit -o jsonpath='{.spec.containers[0].securityContext.runAsUser}')
-    if [[ "$user" == "2000" ]]; then
-      score=$((score + 4))
-      details+="runAsUser is 2000. "
-    else
-      details+="runAsUser is incorrect. "
-    fi
-  else
-    details+="Pod secure-pod not found. "
-  fi
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+	local score=0
+	local max_points=6
+	local details=""
+	if resource_exists pod secure-pod summit; then
+		score=$((score + 2))
+		details+="Pod secure-pod exists. "
+		local user=$(kubectl get pod secure-pod -n summit -o jsonpath='{.spec.containers[0].securityContext.runAsUser}')
+		if [[ "$user" == "2000" ]]; then
+			score=$((score + 4))
+			details+="runAsUser is 2000. "
+		else
+			details+="runAsUser is incorrect. "
+		fi
+	else
+		details+="Pod secure-pod not found. "
+	fi
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q13() {
-  local score=0
-  local max_points=6
-  local details=""
-  if resource_exists rolebinding master-binding pinnacle; then
-    score=$((score + 6))
-    details+="Rolebinding master-binding exists. "
-  else
-    details+="Rolebinding master-binding not found. "
-  fi
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+	local score=0
+	local max_points=6
+	local details=""
+	if resource_exists rolebinding master-binding pinnacle; then
+		score=$((score + 6))
+		details+="Rolebinding master-binding exists. "
+	else
+		details+="Rolebinding master-binding not found. "
+	fi
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q14() {
-  local score=0
-  local max_points=6
-  local details=""
-  if resource_exists pod inject-pod zenith; then
-    score=$((score + 2))
-    details+="Pod inject-pod exists. "
-    local env=$(kubectl get pod inject-pod -n zenith -o jsonpath='{.spec.containers[0].envFrom}')
-    local vol=$(kubectl get pod inject-pod -n zenith -o jsonpath='{.spec.volumes}')
-    if [[ "$env" == *"configMapRef"* || "$env" == *"app-config"* || "$vol" == *"secret"* ]]; then
-      score=$((score + 4))
-      details+="ConfigMap or Secret mounted. "
-    else
-      details+="ConfigMap/Secret not properly injected. "
-    fi
-  else
-    details+="Pod inject-pod not found. "
-  fi
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+	local score=0
+	local max_points=6
+	local details=""
+	if resource_exists pod inject-pod zenith; then
+		score=$((score + 2))
+		details+="Pod inject-pod exists. "
+		local env=$(kubectl get pod inject-pod -n zenith -o jsonpath='{.spec.containers[0].envFrom}')
+		local vol=$(kubectl get pod inject-pod -n zenith -o jsonpath='{.spec.volumes}')
+		if [[ "$env" == *"configMapRef"* || "$env" == *"app-config"* || "$vol" == *"secret"* ]]; then
+			score=$((score + 4))
+			details+="ConfigMap or Secret mounted. "
+		else
+			details+="ConfigMap/Secret not properly injected. "
+		fi
+	else
+		details+="Pod inject-pod not found. "
+	fi
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q15() {
-  local score=0
-  local max_points=6
-  local details=""
-  if resource_exists limitrange cpu-limits crown; then
-    score=$((score + 3))
-    details+="LimitRange exists. "
-  else
-    details+="LimitRange missing. "
-  fi
-  if resource_exists resourcequota compute-quota crown; then
-    score=$((score + 3))
-    details+="ResourceQuota exists. "
-  else
-    details+="ResourceQuota missing. "
-  fi
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+	local score=0
+	local max_points=6
+	local details=""
+	if resource_exists limitrange cpu-limits crown; then
+		score=$((score + 3))
+		details+="LimitRange exists. "
+	else
+		details+="LimitRange missing. "
+	fi
+	if resource_exists resourcequota compute-quota crown; then
+		score=$((score + 3))
+		details+="ResourceQuota exists. "
+	else
+		details+="ResourceQuota missing. "
+	fi
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q16() {
-  local score=0
-  local max_points=6
-  local details=""
-  if kubectl get pv glory-pv &>/dev/null; then
-    score=$((score + 3))
-    details+="PV glory-pv exists. "
-  else
-    details+="PV glory-pv missing. "
-  fi
-  if resource_exists pvc glory-pvc glory; then
-    score=$((score + 3))
-    details+="PVC glory-pvc exists. "
-  else
-    details+="PVC glory-pvc missing. "
-  fi
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+	local score=0
+	local max_points=6
+	local details=""
+	if kubectl get pv glory-pv &>/dev/null; then
+		score=$((score + 3))
+		details+="PV glory-pv exists. "
+	else
+		details+="PV glory-pv missing. "
+	fi
+	if resource_exists pvc glory-pvc glory; then
+		score=$((score + 3))
+		details+="PVC glory-pvc exists. "
+	else
+		details+="PVC glory-pvc missing. "
+	fi
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q17() {
-  local score=0
-  local max_points=7
-  local details=""
-  if resource_exists networkpolicy allow-web legacy; then
-    score=$((score + 7))
-    details+="NetworkPolicy allow-web exists. "
-  else
-    details+="NetworkPolicy allow-web missing. "
-  fi
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+	local score=0
+	local max_points=7
+	local details=""
+	if resource_exists networkpolicy allow-web legacy; then
+		score=$((score + 7))
+		details+="NetworkPolicy allow-web exists. "
+	else
+		details+="NetworkPolicy allow-web missing. "
+	fi
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q18() {
-  local score=0
-  local max_points=7
-  local details=""
-  if resource_exists ingress mastery-ing mastery; then
-    score=$((score + 7))
-    details+="Ingress mastery-ing exists. "
-  else
-    details+="Ingress mastery-ing missing. "
-  fi
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+	local score=0
+	local max_points=7
+	local details=""
+	if resource_exists ingress mastery-ing mastery; then
+		score=$((score + 7))
+		details+="Ingress mastery-ing exists. "
+	else
+		details+="Ingress mastery-ing missing. "
+	fi
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q19() {
-  local score=0
-  local max_points=6
-  local details=""
-  if resource_exists svc ascend-svc ascend; then
-    score=$((score + 2))
-    details+="Service ascend-svc exists. "
-    local type=$(kubectl get svc ascend-svc -n ascend -o jsonpath='{.spec.type}')
-    if [[ "$type" == "NodePort" ]]; then
-      score=$((score + 4))
-      details+="Service is NodePort. "
-    else
-      details+="Service is not NodePort. "
-    fi
-  else
-    details+="Service ascend-svc missing. "
-  fi
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+	local score=0
+	local max_points=6
+	local details=""
+	if resource_exists svc ascend-svc ascend; then
+		score=$((score + 2))
+		details+="Service ascend-svc exists. "
+		local type=$(kubectl get svc ascend-svc -n ascend -o jsonpath='{.spec.type}')
+		if [[ "$type" == "NodePort" ]]; then
+			score=$((score + 4))
+			details+="Service is NodePort. "
+		else
+			details+="Service is not NodePort. "
+		fi
+	else
+		details+="Service ascend-svc missing. "
+	fi
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }
 
 score_q20() {
-  local score=0
-  local max_points=6
-  local details=""
-  if [ -f "./exam/course/20/dns-output.txt" ] || [ -f "./exam/course/20/dns-output.txt" ]; then
-    score=6
-    details+="Output file dns-output.txt exists. "
-  else
-    details+="Output file dns-output.txt missing. "
-  fi
-  echo "$score/$max_points"
-  echo "DETAILS:$details"
+	local score=0
+	local max_points=6
+	local details=""
+	if [ -f "./exam/course/20/dns-output.txt" ] || [ -f "./exam/course/20/dns-output.txt" ]; then
+		score=6
+		details+="Output file dns-output.txt exists. "
+	else
+		details+="Output file dns-output.txt missing. "
+	fi
+	echo "$score/$max_points"
+	echo "DETAILS:$details"
 }

--- a/exams/ckad-simulation20/solutions.md
+++ b/exams/ckad-simulation20/solutions.md
@@ -3,6 +3,7 @@
 ---
 
 ## Question 1 | Kubernetes Practice
+
 ```bash
 cat <<EOF > ./exam/course/1/Dockerfile
 FROM golang:1.20 AS builder
@@ -21,11 +22,13 @@ EOF
 kubectl run musashi-pod --image=localhost:5000/musashi-app:v1 -n apex --dry-run=client -o yaml > ./exam/course/1/pod.yaml
 kubectl apply -f ./exam/course/1/pod.yaml
 ```
+
 Explanation: We use a multi-stage Dockerfile to build and then copy to a smaller alpine image, ensuring a non-root user is used.
 
 ---
 
 ## Question 2 | Kubernetes Practice
+
 ```bash
 cat <<EOF > ./exam/course/2/multi-pod.yaml
 apiVersion: v1
@@ -58,11 +61,13 @@ spec:
 EOF
 kubectl apply -f ./exam/course/2/multi-pod.yaml
 ```
+
 Explanation: Defines a three-container pod sharing an emptyDir volume.
 
 ---
 
 ## Question 3 | Kubernetes Practice
+
 ```bash
 cat <<EOF > ./exam/course/3/job.yaml
 apiVersion: batch/v1
@@ -83,22 +88,26 @@ spec:
 EOF
 kubectl apply -f ./exam/course/3/job.yaml
 ```
+
 Explanation: Creates a job with specific completions and parallelism.
 
 ---
 
 ## Question 4 | Kubernetes Practice
+
 ```bash
 kubectl create cronjob db-backup --image=postgres:15 --schedule="*/15 * * * *" -n zenith --dry-run=client -o yaml > ./exam/course/4/cronjob.yaml
 # Add successfulJobsHistoryLimit: 3 and failedJobsHistoryLimit: 1
 # Update command
 kubectl apply -f ./exam/course/4/cronjob.yaml
 ```
+
 Explanation: CronJob with specific history limits and command.
 
 ---
 
 ## Question 5 | Kubernetes Practice
+
 ```bash
 helm create ./exam/course/5/my-chart
 cat <<EOF > ./exam/course/5/values.yaml
@@ -109,21 +118,25 @@ image:
 EOF
 helm install crown-release ./exam/course/5/my-chart -n crown -f ./exam/course/5/values.yaml
 ```
+
 Explanation: Creates a Helm chart and installs it using custom values.
 
 ---
 
 ## Question 6 | Kubernetes Practice
+
 ```bash
 kubectl set image deployment/glory-deploy nginx=nginx:1.25 -n glory --record
 kubectl rollout undo deployment/glory-deploy -n glory
 kubectl scale deployment/glory-deploy --replicas=5 -n glory
 ```
+
 Explanation: Updates, rolls back, and scales a deployment.
 
 ---
 
 ## Question 7 | Kubernetes Practice
+
 ```bash
 cat <<EOF > ./exam/course/7/canary.yaml
 apiVersion: apps/v1
@@ -147,11 +160,13 @@ spec:
 EOF
 kubectl apply -f ./exam/course/7/canary.yaml
 ```
+
 Explanation: Adds a canary deployment matching the main deployment's selector.
 
 ---
 
 ## Question 8 | Kubernetes Practice
+
 ```bash
 cat <<EOF > ./exam/course/8/prod/kustomization.yaml
 resources:
@@ -169,105 +184,130 @@ patches:
 EOF
 kubectl apply -k ./exam/course/8/prod -n mastery
 ```
+
 Explanation: Sets up a Kustomize overlay to patch replicas and add labels.
 
 ---
 
 ## Question 9 | Kubernetes Practice
+
 ```bash
 # Debug bug-1 (crashloopbackoff due to typo in command)
 # Debug bug-2 (pending due to resource constraints)
 # Debug bug-3 (imagepullbackoff due to wrong image name)
 ```
+
 Explanation: Fixes various pod issues.
 
 ---
 
 ## Question 10 | Kubernetes Practice
+
 ```bash
 kubectl logs triumph-app -n triumph | grep ERROR > ./exam/course/10/logs.txt
 ```
+
 Explanation: Extracts specific log lines to a file.
 
 ---
 
 ## Question 11 | Kubernetes Practice
+
 ```bash
 kubectl debug distroless-pod -it --image=busybox -n apex -- target=main
 # nslookup kubernetes.default
 ```
+
 Explanation: Uses ephemeral container for debugging.
 
 ---
 
 ## Question 12 | Kubernetes Practice
+
 ```bash
 # YAML with SecurityContext
 ```
+
 Explanation: Applies SecurityContext to the container.
 
 ---
 
 ## Question 13 | Kubernetes Practice
+
 ```bash
 kubectl create sa sword-master -n pinnacle
 kubectl create role blade-reader --verb=get,list,watch --resource=pods,configmaps -n pinnacle
 kubectl create rolebinding master-binding --role=blade-reader --serviceaccount=pinnacle:sword-master -n pinnacle
 ```
+
 Explanation: Creates RBAC resources.
 
 ---
 
 ## Question 14 | Kubernetes Practice
+
 ```bash
 # YAML with ConfigMap and Secret mounts
 ```
+
 Explanation: Injects config map as env vars and secret as a volume.
 
 ---
 
 ## Question 15 | Kubernetes Practice
+
 ```bash
 # YAML with LimitRange and ResourceQuota
 ```
+
 Explanation: Configures resource constraints.
 
 ---
 
 ## Question 16 | Kubernetes Practice
+
 ```bash
 # YAML with PV, PVC, Pod
 ```
+
 Explanation: Creates storage resources.
 
 ---
 
 ## Question 17 | Kubernetes Practice
+
 ```bash
 # YAML with NetworkPolicy
 ```
+
 Explanation: Sets up default deny and specific allow policy.
 
 ---
 
 ## Question 18 | Kubernetes Practice
+
 ```bash
 # YAML with Ingress
 ```
+
 Explanation: Configures ingress rules.
 
 ---
 
 ## Question 19 | Kubernetes Practice
+
 ```bash
 kubectl create svc nodeport ascend-svc --tcp=80:80 --node-port=30080 -n ascend
 ```
+
 Explanation: Exposes a NodePort service.
 
 ---
 
 ## Question 20 | Kubernetes Practice
+
 ```bash
 # kubectl run ...
 ```
+
 Explanation: Queries DNS.


### PR DESCRIPTION
## Description

`main` CI has been red since the #108 merge (run 33314316449): the `lint` job fails on pre-commit, which blocks `security`, `test` and `build`.

This PR fixes all of it:

- **Helm chart templates excluded from YAML linting**: sims 13 (`storm-chart`) and 18 (`genesis-web-chart`) introduced the first local Helm charts in the repo. Their `templates/*.yaml` contain Go templating and are not valid YAML, which crashed `check-yaml` and `yamllint`. A `-chart/templates/` exclusion is added for both hooks — `Chart.yaml` and `values.yaml` remain linted.
- **yamllint indentation fixed** in `exams/ckad-simulation16/manifests/setup/setup.yaml` (EndpointSlice block, lines 139-145).
- **Pre-commit auto-fixes applied across sims 12-20**: end-of-file, trailing whitespace, shfmt formatting of `scoring-functions.sh`/`post-setup.sh`, markdownlint blank-line fixes in `questions.md`/`solutions.md`. Purely mechanical — no exam content changed. One residual shfmt drift in `sim1/scoring-functions.sh` fixed in passing.

## Verification

- `uv run pre-commit run --all-files`: 18/18 hooks green
- `./tests/run-tests.sh`: 52/52 tests, 5/5 suites pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
