### PR TITLE
fix: ensure DETAILS is never empty in scoring functions (sims 12-18, 20)

### DIFF
--- a/exams/ckad-simulation12/scoring-functions.sh
+++ b/exams/ckad-simulation12/scoring-functions.sh
@@ -29,6 +29,7 @@ score_q1() {
 		details+="Dockerfile not found. "
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -58,6 +59,7 @@ score_q2() {
 		details+="Pod data-processor not found in crescent namespace. "
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -81,6 +83,7 @@ score_q3() {
 		details+="Cronjob nightly-backup not found in twilight namespace. "
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -106,6 +109,7 @@ score_q4() {
 		details+="Pod legacy-app not found in eclipse namespace. "
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -123,6 +127,7 @@ score_q5() {
 		details+="Release not rolled back to 1. "
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -146,6 +151,7 @@ score_q6() {
 		details+="Deployment slow-start-app not found in shadow namespace. "
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -167,6 +173,7 @@ score_q7() {
 		details+="Deployment critical-processor not found in nightfall namespace. "
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -190,6 +197,7 @@ score_q8() {
 		details+="Files patch.json or kustomization.yaml missing. "
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -215,6 +223,7 @@ score_q9() {
 		details+="Pod metrics-gatherer not found. "
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -234,6 +243,7 @@ score_q10() {
 		details+="cpu-usage.txt not found. "
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -259,6 +269,7 @@ score_q11() {
 		details+="Pod logger not found. "
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -284,6 +295,7 @@ score_q12() {
 		details+="Pod combined-app not found. "
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -306,6 +318,7 @@ score_q13() {
 		details+="ConfigMap static-config not found. "
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -339,6 +352,7 @@ score_q14() {
 		details+="Pod secure-pod not found. "
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -356,6 +370,7 @@ score_q15() {
 		details+="Token not updated. "
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -382,6 +397,7 @@ score_q16() {
 		details+="ResourceQuota compute-quota not found. "
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -407,6 +423,7 @@ score_q17() {
 		details+="NetworkPolicy deny-external not found. "
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -432,6 +449,7 @@ score_q18() {
 		details+="Ingress star-ingress not found. "
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -457,6 +475,7 @@ score_q19() {
 		details+="Service db-ext-svc not found. "
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -478,6 +497,7 @@ score_q20() {
 		details+="nslookup.txt not found. "
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }

--- a/exams/ckad-simulation13/scoring-functions.sh
+++ b/exams/ckad-simulation13/scoring-functions.sh
@@ -20,6 +20,7 @@ score_q1() {
 		details="Image fujin-api:v2 not found in registry"
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -45,6 +46,7 @@ score_q2() {
 	else
 		details="Pod wind-logger not found"
 	fi
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -66,6 +68,7 @@ score_q3() {
 	else
 		details="Job storm-processor not found"
 	fi
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -93,6 +96,7 @@ score_q4() {
 	else
 		details="$details; File not created"
 	fi
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -117,6 +121,7 @@ score_q5() {
 	else
 		details="Helm deployment not found"
 	fi
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -138,6 +143,7 @@ score_q6() {
 	else
 		details="Deployment cyclone-web not found"
 	fi
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -158,6 +164,7 @@ score_q7() {
 	else
 		details="Service zephyr-svc not found"
 	fi
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -178,6 +185,7 @@ score_q8() {
 		score=$((score + 3))
 		details="$details; kustomization.yaml created"
 	fi
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -198,6 +206,7 @@ score_q9() {
 	else
 		details="Pod memory-hog not found"
 	fi
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -218,6 +227,7 @@ score_q10() {
 	else
 		details="top-pods.txt not found"
 	fi
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -238,6 +248,7 @@ score_q11() {
 	else
 		details="Pod monsoon-checker not found"
 	fi
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -258,6 +269,7 @@ score_q12() {
 	else
 		details="Pod secret-reader not found"
 	fi
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -275,6 +287,7 @@ score_q13() {
 		score=$((score + 3))
 		details="$details; RoleBinding exists"
 	fi
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -295,6 +308,7 @@ score_q14() {
 	else
 		details="Pod secure-storage not found"
 	fi
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -310,6 +324,7 @@ score_q15() {
 	else
 		details="LimitRange not found"
 	fi
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -330,6 +345,7 @@ score_q16() {
 	else
 		details="Pod zephyr-api not found"
 	fi
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -350,6 +366,7 @@ score_q17() {
 	else
 		details="NetworkPolicy not found"
 	fi
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -370,6 +387,7 @@ score_q18() {
 	else
 		details="Ingress not found"
 	fi
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -390,6 +408,7 @@ score_q19() {
 	else
 		details="Service mistral-db-headless not found"
 	fi
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -409,6 +428,7 @@ score_q20() {
 	else
 		details="File svc-env.txt not found"
 	fi
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }

--- a/exams/ckad-simulation14/scoring-functions.sh
+++ b/exams/ckad-simulation14/scoring-functions.sh
@@ -36,6 +36,7 @@ score_q1() {
 		details+="Dockerfile not found."
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -70,6 +71,7 @@ score_q2() {
 		details+="Pod thunder-logger not found in thunder namespace."
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -104,6 +106,7 @@ score_q3() {
 		details+="CronJob lightning-strike not found."
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -134,6 +137,7 @@ score_q4() {
 		details+="Pod app-with-wait not found."
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -161,6 +165,7 @@ score_q5() {
 		details+="output.yaml not found."
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -185,6 +190,7 @@ score_q6() {
 		details+="Deployment api-gateway not found."
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -219,6 +225,7 @@ score_q7() {
 		details+="Canary deployment not found."
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -243,6 +250,7 @@ score_q8() {
 		details+="Deployment api-worker not found."
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -264,6 +272,7 @@ score_q9() {
 		details+="Pod not found."
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -286,6 +295,7 @@ score_q10() {
 		details+="events.txt not found."
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -320,6 +330,7 @@ score_q11() {
 		details+="Pod complex-app not found."
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -348,6 +359,7 @@ score_q12() {
 		details+="Pod env-info not found."
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -376,6 +388,7 @@ score_q13() {
 		details+="Pod secure-net not found."
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -404,6 +417,7 @@ score_q14() {
 		details+="Secret db-credentials not found."
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -433,6 +447,7 @@ score_q15() {
 		details+="Pod arg-reader not found."
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -468,6 +483,7 @@ score_q16() {
 		details+="ClusterRoleBinding not found."
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -500,6 +516,7 @@ score_q17() {
 		details+="NetworkPolicy strict-ingress not found."
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -524,6 +541,7 @@ score_q18() {
 		details+="Ingress default-ing not found."
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -554,6 +572,7 @@ score_q19() {
 		details+="Service sticky-svc not found."
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -578,6 +597,7 @@ score_q20() {
 		details+="response.txt not found."
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }

--- a/exams/ckad-simulation15/scoring-functions.sh
+++ b/exams/ckad-simulation15/scoring-functions.sh
@@ -33,6 +33,7 @@ score_q1() {
 		details+="Dockerfile not found. "
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS: $details"
 }
@@ -68,6 +69,7 @@ score_q2() {
 		details+="Pod $pod not found. "
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS: $details"
 }
@@ -111,6 +113,7 @@ score_q3() {
 		details+="CronJob $cj not found. "
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS: $details"
 }
@@ -138,6 +141,7 @@ score_q4() {
 		details+="Pod $pod not found. "
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS: $details"
 }
@@ -156,6 +160,7 @@ score_q5() {
 		details+="Helm release ocean-api still exists. "
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS: $details"
 }
@@ -192,6 +197,7 @@ score_q6() {
 		details+="Deploy $dep not found. "
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS: $details"
 }
@@ -216,6 +222,7 @@ score_q7() {
 		details+="Deploy $dep not found. "
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS: $details"
 }
@@ -255,6 +262,7 @@ score_q8() {
 		details+="Service app-svc created via kustomize. "
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS: $details"
 }
@@ -285,6 +293,7 @@ score_q9() {
 		details+="Pod $pod not found. "
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS: $details"
 }
@@ -308,6 +317,7 @@ score_q10() {
 		details+="File events.txt not found. "
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS: $details"
 }
@@ -335,6 +345,7 @@ score_q11() {
 		details+="Pod $pod not found. "
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS: $details"
 }
@@ -369,6 +380,7 @@ score_q12() {
 		details+="Pod $pod not found. "
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS: $details"
 }
@@ -403,6 +415,7 @@ score_q13() {
 		details+="Pod $pod not found. "
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS: $details"
 }
@@ -439,6 +452,7 @@ score_q14() {
 		details+="NetworkPolicy not found. "
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS: $details"
 }
@@ -463,6 +477,7 @@ score_q15() {
 		details+="Pod $pod not found. "
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS: $details"
 }
@@ -498,6 +513,7 @@ score_q16() {
 		details+="PDB $pdb not found. "
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS: $details"
 }
@@ -523,6 +539,7 @@ score_q17() {
 		details+="Policy allow-web not found. "
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS: $details"
 }
@@ -547,6 +564,7 @@ score_q18() {
 		details+="Service $svc not found. "
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS: $details"
 }
@@ -578,6 +596,7 @@ score_q19() {
 		details+="Service not found. "
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS: $details"
 }
@@ -609,6 +628,7 @@ score_q20() {
 		details+="Ingress $ing not found. "
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS: $details"
 }

--- a/exams/ckad-simulation16/scoring-functions.sh
+++ b/exams/ckad-simulation16/scoring-functions.sh
@@ -26,6 +26,7 @@ score_q1() {
 		details="Pod not found"
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -48,6 +49,7 @@ score_q2() {
 		details="Pod not found"
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -70,6 +72,7 @@ score_q3() {
 		details="Job not found"
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -92,6 +95,7 @@ score_q4() {
 		details="Pod not found"
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -114,6 +118,7 @@ score_q5() {
 		details="Helm release not found"
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -137,6 +142,7 @@ score_q6() {
 		details="Deployment not found"
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -159,6 +165,7 @@ score_q7() {
 		details="Deployment not found"
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -181,6 +188,7 @@ score_q8() {
 		details="Deployment not found in lyric namespace"
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -202,6 +210,7 @@ score_q9() {
 		details="Pod not found"
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -223,6 +232,7 @@ score_q10() {
 		details="Metrics file not found"
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -246,6 +256,7 @@ score_q11() {
 		details="Pod not found"
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -268,6 +279,7 @@ score_q12() {
 		details="Pod not found"
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -289,6 +301,7 @@ score_q13() {
 		details="ConfigMap not found"
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -311,6 +324,7 @@ score_q14() {
 		details="Pod not found"
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -332,6 +346,7 @@ score_q15() {
 		details="Token file not found"
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -354,6 +369,7 @@ score_q16() {
 		details="NetworkPolicy not found"
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -376,6 +392,7 @@ score_q17() {
 		details="NetworkPolicy not found"
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -398,6 +415,7 @@ score_q18() {
 		details="Ingress not found"
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -419,6 +437,7 @@ score_q19() {
 		details="Endpoints file not found"
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -441,6 +460,7 @@ score_q20() {
 		details="Service not found"
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }

--- a/exams/ckad-simulation17/scoring-functions.sh
+++ b/exams/ckad-simulation17/scoring-functions.sh
@@ -38,6 +38,7 @@ score_q1() {
 		details+="Pod entry-override not found. "
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -73,6 +74,7 @@ score_q2() {
 		details+="Pod web-setup not found. "
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -101,6 +103,7 @@ score_q3() {
 		details+="CronJob siege-report not found. "
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -129,6 +132,7 @@ score_q4() {
 		details+="Pod process-monitor not found. "
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -154,6 +158,7 @@ score_q5() {
 		details+="Helm release not deployed or failed. "
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -178,6 +183,7 @@ score_q6() {
 		details+="Deployment not found. "
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -202,6 +208,7 @@ score_q7() {
 		details+="Green deployment not found. "
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -230,6 +237,7 @@ score_q8() {
 		details+="Deployment vanguard-web not found. "
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -255,6 +263,7 @@ score_q9() {
 		details+="Pod data-processor not found. "
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -282,6 +291,7 @@ score_q10() {
 		details+="Pod secure-app not found. "
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -309,6 +319,7 @@ score_q11() {
 		details+="Deployment weapon-smith not found. "
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -337,6 +348,7 @@ score_q12() {
 		details+="Pod resource-aware not found. "
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -368,6 +380,7 @@ score_q13() {
 		fi
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -396,6 +409,7 @@ score_q14() {
 		details+="Pod secure-workload not found. "
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -427,6 +441,7 @@ score_q15() {
 		details+="Pod db-consumer not found. "
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -449,6 +464,7 @@ score_q16() {
 		fi
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -477,6 +493,7 @@ score_q17() {
 		details+="NetPol protect-db not found. "
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -501,6 +518,7 @@ score_q18() {
 		details+="Canary ingress not found. "
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -529,6 +547,7 @@ score_q19() {
 		fi
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -553,6 +572,7 @@ score_q20() {
 		details+="File ./exam/course/20/coredns.yaml not found. "
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }

--- a/exams/ckad-simulation18/scoring-functions.sh
+++ b/exams/ckad-simulation18/scoring-functions.sh
@@ -42,6 +42,7 @@ score_q1() {
 		details+="Pod genesis-pod not found. "
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -76,6 +77,7 @@ score_q2() {
 		details+="Pod data-transformer not found. "
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -108,6 +110,7 @@ score_q3() {
 		details+="Job index-processor not found. "
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -136,6 +139,7 @@ score_q4() {
 		details+="Pod graceful-shutdown not found. "
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -164,6 +168,7 @@ score_q5() {
 		details+="Helm release genesis-web not found. "
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -197,6 +202,7 @@ score_q6() {
 		details+="PDB terra-pdb not found. "
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -230,6 +236,7 @@ score_q7() {
 		details+="Deployment eden-api not found. "
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -252,6 +259,7 @@ score_q8() {
 		details+="Secret matrix-secret not found (ensure disableNameSuffixHash is used). "
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -274,6 +282,7 @@ score_q9() {
 		details+="Pod stuck-pod not found. "
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -299,6 +308,7 @@ score_q10() {
 		details+="File not found. "
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -325,6 +335,7 @@ score_q11() {
 		details+="Script check.sh not found. "
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -352,6 +363,7 @@ score_q12() {
 		details+="Pod projected-pod not found. "
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -376,6 +388,7 @@ score_q13() {
 		details+="Secret static-creds not found. "
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -403,6 +416,7 @@ score_q14() {
 		details+="Pod secure-pod not found. "
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -435,6 +449,7 @@ score_q15() {
 		details+="ClusterRole aggregated-monitor not found. "
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -463,6 +478,7 @@ score_q16() {
 		details+="ResourceQuota priority-quota not found. "
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -485,6 +501,7 @@ score_q17() {
 		details+="NetworkPolicy allow-named-port not found. "
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -513,6 +530,7 @@ score_q18() {
 		details+="Ingress cosmos-ingress not found. "
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -540,6 +558,7 @@ score_q19() {
 		details+="File fqdn.txt not found. "
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -567,6 +586,7 @@ score_q20() {
 		details+="NetworkPolicy isolate-namespace not found. "
 	fi
 
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }

--- a/exams/ckad-simulation20/scoring-functions.sh
+++ b/exams/ckad-simulation20/scoring-functions.sh
@@ -25,6 +25,7 @@ score_q1() {
 	else
 		details+="Pod musashi-pod not found. "
 	fi
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -46,6 +47,7 @@ score_q2() {
 	else
 		details+="Pod tri-blade not found. "
 	fi
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -68,6 +70,7 @@ score_q3() {
 	else
 		details+="Job data-processor not found. "
 	fi
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -89,6 +92,7 @@ score_q4() {
 	else
 		details+="CronJob db-backup not found. "
 	fi
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -103,6 +107,7 @@ score_q5() {
 	else
 		details+="Helm release crown-release not found. "
 	fi
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -127,6 +132,7 @@ score_q6() {
 	else
 		details+="Deployment glory-deploy not found. "
 	fi
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -148,6 +154,7 @@ score_q7() {
 	else
 		details+="Canary deployment not found. "
 	fi
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -169,6 +176,7 @@ score_q8() {
 	else
 		details+="Deployment my-app not found. "
 	fi
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -185,6 +193,7 @@ score_q9() {
 		score=$((count * 2))
 		details+="$count/3 broken pods are running. "
 	fi
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -205,6 +214,7 @@ score_q10() {
 	else
 		details+="File logs.txt not found. "
 	fi
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -220,6 +230,7 @@ score_q11() {
 	else
 		details+="No ephemeral container found on distroless-pod. "
 	fi
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -241,6 +252,7 @@ score_q12() {
 	else
 		details+="Pod secure-pod not found. "
 	fi
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -255,6 +267,7 @@ score_q13() {
 	else
 		details+="Rolebinding master-binding not found. "
 	fi
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -277,6 +290,7 @@ score_q14() {
 	else
 		details+="Pod inject-pod not found. "
 	fi
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -297,6 +311,7 @@ score_q15() {
 	else
 		details+="ResourceQuota missing. "
 	fi
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -317,6 +332,7 @@ score_q16() {
 	else
 		details+="PVC glory-pvc missing. "
 	fi
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -331,6 +347,7 @@ score_q17() {
 	else
 		details+="NetworkPolicy allow-web missing. "
 	fi
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -345,6 +362,7 @@ score_q18() {
 	else
 		details+="Ingress mastery-ing missing. "
 	fi
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -366,6 +384,7 @@ score_q19() {
 	else
 		details+="Service ascend-svc missing. "
 	fi
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }
@@ -380,6 +399,7 @@ score_q20() {
 	else
 		details+="Output file dns-output.txt missing. "
 	fi
+	[ -z "$details" ] && details="No criteria matched."
 	echo "$score/$max_points"
 	echo "DETAILS:$details"
 }


### PR DESCRIPTION
## Description

Fixes #132.

Some `score_q` functions initialise `local details=""` but have code paths where nothing is ever appended — typically when a file exists but no inner check matches. This caused candidates to see a failed question with a completely blank `DETAILS:` line and no explanation.

## Fix

Added a single guard line just before the final `echo` in every `score_q` function:

```bash
[ -z "$details" ] && details="No criteria matched."
echo "$score/$max_points"
echo "DETAILS:$details"
```

This is the approach suggested by @xgueret in the issue. If every inner check was skipped or missed, the candidate now sees `DETAILS:No criteria matched.` instead of `DETAILS:` (blank).

## Verified on live cluster

Before fix (real main):
```
DETAILS:          ← blank
```

After fix (this branch):
```
DETAILS:No criteria matched.
```

Tested against sim12, sim13, sim17 which were the specific cases reported in the issue.

## Changes

| Sim | Guards added |
|-----|--------------|
| sim12 | 20 (one per score_q function) |
| sim13 | 20 |
| sim14 | 20 |
| sim15 | 20 |
| sim16 | 20 |
| sim17 | 20 |
| sim18 | 20 |
| sim20 | 20 |

**8 files changed, 160 insertions. No logic changes — safety net only.**

All `bash -n` syntax checks pass.

## Related

Fixes #132
Follow-up to #125